### PR TITLE
Reload leaderboards when props updated

### DIFF
--- a/source/components/leaderboard/index.js
+++ b/source/components/leaderboard/index.js
@@ -21,6 +21,12 @@ class Leaderboard extends Component {
     this.fetchLeaderboard()
   }
 
+  componentDidUpdate (prevProps) {
+    if (this.props !== prevProps) {
+      this.fetchLeaderboard()
+    }
+  }
+
   setFilter (q) {
     this.fetchLeaderboard(q)
   }
@@ -36,6 +42,11 @@ class Leaderboard extends Component {
       limit,
       page
     } = this.props
+
+    this.setState({
+      status: 'fetching',
+      data: null
+    })
 
     fetchLeaderboard({
       campaign,


### PR DESCRIPTION
Problem

In your app, if you change props based on a toggle or some other
change (e.g. on toggle, show teams, otherwise, show individuals), the
leaderboard won't update. This is because it only fetches data on
componentDidMount

Solution

Add a componentDidUpdate hook, which will refresh the leaderboard if the
props you pass it have changed