### PR TITLE
Add FitnessLeaderboard component

### DIFF
--- a/source/api/fitness-leaderboard/__tests__/fetch-test.js
+++ b/source/api/fitness-leaderboard/__tests__/fetch-test.js
@@ -1,0 +1,91 @@
+import moxios from 'moxios'
+import { fetchFitnessLeaderboard } from '..'
+import { instance } from '../../../utils/client'
+
+describe ('Fetch Fitness Leaderboards', () => {
+  beforeEach (() => {
+    moxios.install(instance)
+  })
+
+  afterEach (() => {
+    moxios.uninstall(instance)
+  })
+
+  it ('uses the correct url to fetch a leaderboard', (done) => {
+    fetchFitnessLeaderboard({ campaign_id: 'au-6839', group_value: 'group123' })
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent()
+      expect(request.url).to.contain('https://everydayhero.com/api/v2/search/fitness_activities_totals')
+      expect(request.url).to.contain('campaign_id=au-6839')
+      expect(request.url).to.contain('group_value=group123')
+      done()
+    })
+  })
+
+  it ('throws if no params are passed in', () => {
+    const test = () => fetchFitnessLeaderboard()
+    expect(test).to.throw
+  })
+
+  it ('uses the correct url to fetch a campaign leaderboard', (done) => {
+    fetchFitnessLeaderboard({ campaign: 'au-6839' })
+    moxios.wait(function () {
+      const request = moxios.requests.mostRecent()
+      expect(request.url).to.contain('https://everydayhero.com/api/v2/search/fitness_activities_totals')
+      expect(request.url).to.contain('campaign_id=au-6839')
+      done()
+    })
+  })
+
+  it ('uses the correct url to fetch a leaderboard for multiple campaigns', (done) => {
+    fetchFitnessLeaderboard({ campaign: ['au-6839', 'au-6840']})
+    moxios.wait(function () {
+      const request = moxios.requests.mostRecent()
+      expect(request.url).to.contain('https://everydayhero.com/api/v2/search/fitness_activities_totals')
+      expect(request.url).to.contain('campaign_id[]=au-6839')
+      expect(request.url).to.contain('campaign_id[]=au-6840')
+      done()
+    })
+  })
+
+  it ('uses the correct url to fetch a charity leaderboard', (done) => {
+    fetchFitnessLeaderboard({ charity: 'au-28' })
+    moxios.wait(function () {
+      const request = moxios.requests.mostRecent()
+      expect(request.url).to.contain('https://everydayhero.com/api/v2/search/fitness_activities_totals')
+      expect(request.url).to.contain('charity_id=au-28')
+      done()
+    })
+  })
+
+  it ('uses the correct url to fetch a leaderboard for multiple campaigns', (done) => {
+    fetchFitnessLeaderboard({ charity: ['au-28', 'au-29'] })
+    moxios.wait(function () {
+      const request = moxios.requests.mostRecent()
+      expect(request.url).to.contain('https://everydayhero.com/api/v2/search/fitness_activities_totals')
+      expect(request.url).to.contain('charity_id[]=au-28')
+      expect(request.url).to.contain('charity_id[]=au-29')
+      done()
+    })
+  })
+
+  it ('correctly transforms page type params', (done) => {
+    fetchFitnessLeaderboard({ type: 'team' })
+    moxios.wait(function () {
+      const request = moxios.requests.mostRecent()
+      expect(request.url).to.contain('https://everydayhero.com/api/v2/search/fitness_activities_totals')
+      expect(request.url).to.contain('group_by=teams')
+      done()
+    })
+  })
+
+  it ('correctly transforms activity type params', (done) => {
+    fetchFitnessLeaderboard({ activity: 'run' })
+    moxios.wait(function () {
+      const request = moxios.requests.mostRecent()
+      expect(request.url).to.contain('https://everydayhero.com/api/v2/search/fitness_activities_totals')
+      expect(request.url).to.contain('type=run')
+      done()
+    })
+  })
+})

--- a/source/api/fitness-leaderboard/index.js
+++ b/source/api/fitness-leaderboard/index.js
@@ -1,0 +1,42 @@
+import { get } from '../../utils/client'
+import { required } from '../../utils/params'
+
+export const c = {
+  ENDPOINT: 'api/v2/search/fitness_activities_totals',
+  NAMESPACE: 'app/fitness-leaderboard'
+}
+
+/**
+* @function fetches supporter pages ranked by fitness activities
+*/
+export const fetchFitnessLeaderboard = (params = required()) => {
+  const transforms = {
+    type: (val) => val === 'team' ? 'teams' : 'pages'
+  }
+
+  const mappings = {
+    activity: 'type',
+    type: 'group_by'
+  }
+
+  return get(c.ENDPOINT, params, { mappings, transforms })
+    .then((response) => response.results)
+}
+
+/**
+* @function a default deserializer for leaderboard pages
+*/
+export const deserializeFitnessLeaderboard = ({ page, team, distance_in_meters }, index) => {
+  const detail = team || page
+  return {
+    position: index++,
+    id: detail.id,
+    name: detail.name,
+    charity: detail.charity_name,
+    url: detail.url,
+    image: detail.image.medium_image_url,
+    distance: distance_in_meters,
+    raised: detail.amount.cents,
+    groups: detail.group_values
+  }
+}

--- a/source/api/fitness-leaderboard/readme.md
+++ b/source/api/fitness-leaderboard/readme.md
@@ -1,0 +1,64 @@
+# Goal
+
+Helpers related to fetching pages sorted by fitness activities.
+
+- [Configuration](#configuration)
+- [fetchFitnesseaderboard](#fetchfitnessleaderboard)
+- [deserializeFitnessLeaaderboard](#deserializefitnessleaderboard)
+
+## Configuration
+
+- `namespace` - app/leaderboard
+- `endpoint` - api/v2/search/fitness_activities_totals
+
+## `fetchLeaderboard`
+
+**Purpose**
+
+Fetch pages from Supporter sorted by fitness activities.
+
+**Params**
+
+- `params` (Object) see [paramater list](../readme.md#availableparameters)
+
+**Returns**
+
+A pending promise that will either resolve to:
+
+- Success: the data returned from the request
+- Failure: the error encountered
+
+**Example**
+
+```javascript
+import { fetchFitnessLeaderboard } from 'supporticon/api/fitness-leaderboard'
+
+fetchFitnessLeaderboard({
+  campaign: 'au-123'
+})
+```
+
+## `deserializeLeaderboard`
+
+A default deserializer for deserializing supporter leaderboard pages
+
+**Params**
+
+- `data` {Object} a single supporter page to deserialize
+
+**Returns**
+
+The deserialized supporter page
+
+**Example**
+
+```javascript
+import { deserializeFitnessLeaderboard } from 'supporticon/api/leaderboard'
+
+// ...
+
+return {
+  status: 'fetched',
+  data: payload.data.map(deserializeFitnessLeaderboard)
+}
+```

--- a/source/components/fitness-leaderboard/Readme.md
+++ b/source/components/fitness-leaderboard/Readme.md
@@ -1,0 +1,7 @@
+# Examples
+
+```
+<FitnessLeaderboard
+  campaign='au-21638'
+/>
+```

--- a/source/components/fitness-leaderboard/index.js
+++ b/source/components/fitness-leaderboard/index.js
@@ -1,0 +1,227 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import numbro from 'numbro'
+import Filter from 'constructicon/filter'
+import LeaderboardWrapper from 'constructicon/leaderboard'
+import LeaderboardItem from 'constructicon/leaderboard-item'
+
+import {
+  fetchFitnessLeaderboard,
+  deserializeFitnessLeaderboard
+} from '../../api/fitness-leaderboard'
+
+class FitnessLeaderboard extends Component {
+  constructor () {
+    super()
+    this.setFilter = this.setFilter.bind(this)
+    this.renderLeader = this.renderLeader.bind(this)
+    this.state = { status: 'fetching' }
+  }
+
+  componentDidMount () {
+    this.fetchLeaderboard()
+  }
+
+  componentDidUpdate (prevProps) {
+    if (this.props !== prevProps) {
+      this.fetchLeaderboard()
+    }
+  }
+
+  setFilter (q) {
+    this.fetchLeaderboard(q)
+  }
+
+  fetchLeaderboard (q) {
+    const {
+      campaign,
+      charity,
+      type,
+      group,
+      startDate,
+      endDate,
+      includeManual,
+      excludeVirtual,
+      limit,
+      page
+    } = this.props
+
+    this.setState({
+      status: 'fetching',
+      data: undefined
+    })
+
+    fetchFitnessLeaderboard({
+      campaign,
+      charity,
+      type,
+      group,
+      startDate,
+      endDate,
+      include_manual: includeManual,
+      exclude_virtual: excludeVirtual,
+      limit,
+      page,
+      q
+    })
+      .then((data) => {
+        this.setState({
+          status: 'fetched',
+          data: data.map(deserializeFitnessLeaderboard)
+        })
+      })
+      .catch((error) => {
+        this.setState({
+          status: 'failed'
+        })
+        return Promise.reject(error)
+      })
+  }
+
+  render () {
+    const {
+      status,
+      data = []
+    } = this.state
+
+    const {
+      leaderboard,
+      filter
+    } = this.props
+
+    return (
+      <div>
+        {filter && <Filter onChange={this.setFilter} {...filter} />}
+        <LeaderboardWrapper
+          loading={status === 'fetching'}
+          error={status === 'failed'}
+          children={data.map(this.renderLeader)}
+          {...leaderboard}
+        />
+      </div>
+    )
+  }
+
+  renderLeader (leader, i) {
+    const {
+      leaderboardItem = {},
+      miles
+    } = this.props
+
+    const finalDistance = miles ? leader.distance / 1609.34 : leader.distance / 1000
+
+    return (
+      <LeaderboardItem
+        key={i}
+        title={leader.name}
+        subtitle={leader.charity}
+        image={leader.image}
+        amount={`${numbro(finalDistance).format('0,0')} ${miles ? 'mi.' : 'kms'}`}
+        href={leader.url}
+        {...leaderboardItem}
+      />
+    )
+  }
+}
+
+FitnessLeaderboard.propTypes = {
+  /**
+  * The campaign uid to fetch pages for
+  */
+  campaign: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.array
+  ]),
+
+  /**
+  * The charity uid to fetch pages for
+  */
+  charity: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.array
+  ]),
+
+  /**
+  * The type of page to include in the leaderboard
+  */
+  type: PropTypes.oneOf([ 'individual', 'team' ]),
+
+  /**
+  * The activity type of page to include in the leaderboard (bike, gym, hike, run, sport, swim, walk)
+  */
+  activity: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.array
+  ]),
+
+  /**
+  * The group value(s) to filter by
+  */
+  group: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.array
+  ]),
+
+  /**
+  * Start date filter (ISO Format)
+  */
+  startDate: PropTypes.string,
+
+  /**
+  * End date filter (ISO Format)
+  */
+  endDate: PropTypes.string,
+
+  /**
+  * Include Virtual
+  */
+  includeVirtual: PropTypes.boolean,
+
+  /**
+  * Include Manual
+  */
+  includeManual: PropTypes.boolean,
+
+  /**
+  * Exclude Virtual
+  */
+  excludeVirtual: PropTypes.boolean,
+
+  /**
+  * Unit
+  */
+  miles: PropTypes.boolean,
+
+  /**
+  * The number of records to fetch
+  */
+  limit: PropTypes.number,
+
+  /**
+  * The page to fetch
+  */
+  page: PropTypes.number,
+
+  /**
+  * Props to be passed to the Constructicon Leaderboard component
+  */
+  leaderboard: PropTypes.object,
+
+  /**
+  * Props to be passed to the Constructicon LeaderboardItem component
+  */
+  leaderboardItem: PropTypes.object,
+
+  /**
+  * Props to be passed to the Filter component (false to hide)
+  */
+  filter: PropTypes.any
+}
+
+FitnessLeaderboard.defaultProps = {
+  limit: 10,
+  page: 1,
+  filter: {}
+}
+
+export default FitnessLeaderboard

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -18,6 +18,7 @@ module.exports = {
       name: 'Components',
       components: () => ([
         path.resolve(__dirname, 'source/components/leaderboard', 'index.js'),
+        path.resolve(__dirname, 'source/components/fitness-leaderboard', 'index.js'),
         path.resolve(__dirname, 'source/components/page-search', 'index.js')
       ])
     },


### PR DESCRIPTION
- Filter by all the usual things e.g. start/end dates, teams or
  individuals etc.
- Also filter by activity type, include manual, exclude virtual etc.
- Show in kms or miles
- New api calls to fetch fitness activities w/ tests

![image](https://user-images.githubusercontent.com/1445686/28695038-36d815d2-7370-11e7-89a6-66fc57bde4a2.png)
