### PR TITLE
Add support for team invite token on page creation

### DIFF
--- a/source/api/pages/index.js
+++ b/source/api/pages/index.js
@@ -43,7 +43,8 @@ export const createPage = ({
   nickname,
   slug,
   fitnessGoal,
-  groupValues
+  groupValues,
+  inviteToken
 }) => {
   return post(`${c.ENDPOINT}?access_token=${token}`, {
     campaign_id: campaignId,
@@ -53,7 +54,8 @@ export const createPage = ({
     birthday,
     slug,
     fitness_goal: fitnessGoal,
-    group_values: groupValues
+    group_values: groupValues,
+    token: inviteToken
   })
 }
 


### PR DESCRIPTION
From [the docs](http://developer.everydayhero.com/pages/#create-an-individual-page):

token : _optional_ **string**
An invitation token to join a team. This invitation was created by the team leader and sent to the user that you want to create a supporter page for.