### PR TITLE
Handle FB browser issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/components/single-sign-on-link/index.js
+++ b/source/components/single-sign-on-link/index.js
@@ -1,28 +1,51 @@
-import React from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import Button from 'constructicon/button'
 import { getBaseURL } from '../../utils/client'
 
-const SingleSignOnLink = ({
-  token,
-  pageURL,
-  label,
-  supporterCreateSessionURL = `${getBaseURL()}/api/v2/authentication/sessions`,
-  target,
-  ...props
-}) => (
-  token ? (
-    <form method='POST' action={supporterCreateSessionURL} target={target}>
-      <input type='hidden' name='access_token' value={token} />
-      <input type='hidden' name='return_to' value={pageURL} />
-      <Button {...props} type='submit'>{label}</Button>
-    </form>
-  ) : (
-    <Button tag='a' href={pageURL} target={target} {...props}>
-      {label}
-    </Button>
-  )
-)
+class SingleSignOnLink extends Component {
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      target: props.target
+    }
+  }
+
+  componentDidMount () {
+    const { navigator } = window
+    const ua = navigator.userAgent || navigator.vendor || window.opera
+
+    // Detect FB mobile browser
+    if ((ua.indexOf('FBAN') > -1) || (ua.indexOf('FBAV') > -1)) {
+      this.setState({ target: '_self' })
+    }
+  }
+
+  render () {
+    const {
+      token,
+      pageURL,
+      label,
+      supporterCreateSessionURL = `${getBaseURL()}/api/v2/authentication/sessions`,
+      ...props
+    } = this.props
+
+    const { target } = this.state
+
+    return token ? (
+      <form method='POST' action={supporterCreateSessionURL} target={target}>
+        <input type='hidden' name='access_token' value={token} />
+        <input type='hidden' name='return_to' value={pageURL} />
+        <Button {...props} type='submit'>{label}</Button>
+      </form>
+    ) : (
+      <Button tag='a' href={pageURL} target={target} {...props}>
+        {label}
+      </Button>
+    )
+  }
+}
 
 SingleSignOnLink.propTypes = {
   /**


### PR DESCRIPTION
Avoid submitting forms with target of `_blank` in FB mobile app browser