### PR TITLE
Fix errors in SingleSignOnLink component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/components/single-sign-on-link/index.js
+++ b/source/components/single-sign-on-link/index.js
@@ -7,7 +7,7 @@ const SingleSignOnLink = ({
   token,
   pageURL,
   label,
-  supporterCreateSessionURL,
+  supporterCreateSessionURL = `${getBaseURL()}/api/v2/authentication/sessions`,
   target,
   ...props
 }) => (
@@ -33,12 +33,12 @@ SingleSignOnLink.propTypes = {
   /**
   * The URL of a page
   */
-  pageURL: PropTypes.string.required,
+  pageURL: PropTypes.string.isRequired,
 
   /**
   * Button label
   */
-  label: PropTypes.string,
+  label: PropTypes.any,
 
   /**
   * The target for the form or anchor
@@ -53,7 +53,6 @@ SingleSignOnLink.propTypes = {
 
 SingleSignOnLink.defaultProps = {
   label: 'My Fundraising Page',
-  supporterCreateSessionURL: `${getBaseURL()}/api/v2/authentication/sessions`,
   target: '_self'
 }
 


### PR DESCRIPTION
- Allow for `any` prop type for `label`
- `supporterCreateSessionURL` should be computed at runtime, based on ENV vars
- Fix typo for required proptype