### PR TITLE
Default donation totals to 0

### DIFF
--- a/source/api/donation-totals/__tests__/totals-test.js
+++ b/source/api/donation-totals/__tests__/totals-test.js
@@ -1,5 +1,8 @@
 import moxios from 'moxios'
-import { fetchDonationTotals } from '..'
+import {
+  deserializeDonationTotals,
+  fetchDonationTotals
+} from '..'
 import { instance } from '../../../utils/client'
 
 describe ('Fetch Donation Totals', () => {
@@ -34,5 +37,21 @@ describe ('Fetch Donation Totals', () => {
   it ('throws if no params are passed in', () => {
     const test = () => fetchDonationTotals()
     expect(test).to.throw
+  })
+})
+
+describe ('Deserialize donation totals', () => {
+  it ('Defaults falsy donation sums to 0', () => {
+    const deserializedDonationTotals = deserializeDonationTotals({
+      total_amount_cents: {
+        sum: null,
+        count: 0
+      }
+    })
+
+    expect(deserializedDonationTotals).to.deep.equal({
+      raised: 0,
+      donations: 0
+    })
   })
 })

--- a/source/api/donation-totals/index.js
+++ b/source/api/donation-totals/index.js
@@ -7,7 +7,7 @@ export const c = {
 }
 
 export const deserializeDonationTotals = (totals) => ({
-  raised: totals.total_amount_cents.sum,
+  raised: totals.total_amount_cents.sum || 0,
   donations: totals.total_amount_cents.count
 })
 


### PR DESCRIPTION
Supporter responds with `null` for some reason, instead of 0, which just complicates things when it comes to manipulating the numbers, because we first have to make sure it is, in fact, a number.