### PR TITLE
Add additional fields to deserializePage response (if available)

### DIFF
--- a/source/api/pages/index.js
+++ b/source/api/pages/index.js
@@ -10,17 +10,23 @@ const c = {
 * @function deserializer for supporter pages
 */
 export const deserializePage = (page) => ({
-  id: page.id,
   active: page.active,
-  raised: page.amount.cents,
-  campaign: page.campaign,
-  charity: page.charity,
+  campaign: page.campaign || page.campaign_name,
+  campaignDate: page.campaign_date,
+  charity: page.charity || page.charity_name,
+  coordinates: page.coordinate,
+  donatationUrl: page.donation_url,
   expired: page.expired,
+  groups: page.page_groups,
+  id: page.id,
   image: page.image.medium_image_url,
   name: page.name,
+  raised: page.amount.cents,
+  story: page.story,
   target: page.target_cents,
+  teamPageId: page.team_page_id,
   url: page.url,
-  groups: page.page_groups
+  uuid: page.uuid
 })
 
 /**


### PR DESCRIPTION
The response for pages differs substantially between the following endpoints:

- `api/v2/search/pages`
- `api/v2/search/pages_totals`
- `api/v2/pages`
- `api/v2/pages/:id`

Initially, we provided a minimal number of fields returned by the `api/v2/search/pages` endpoint as the first use in this project was for leaderboards.

However, we now use the `deserializePage` function throughout our projects, notably after page creation through custom registration (and saving into our Redux stores).

Mainly it was missing `uuid` which I required, but it was worth adding other potentially useful data as well when available. The fields will return `null` when the response doesn't return them.