### PR TITLE
Pagination in columns

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/components/leaderboard/index.js
+++ b/source/components/leaderboard/index.js
@@ -132,20 +132,18 @@ class Leaderboard extends Component {
           loading={status === 'fetching'}
           error={status === 'failed'}
           {...leaderboard}>
-          {pageSize ? (
-            <div>
-              {this.paginateLeaderboard()}
-              <Grid justify={'center'}>
-                <GridColumn xs={1}>
-                  <PaginationLink onClick={this.prevPage} rotate={180} disabled={currentPage <= 1} />
-                </GridColumn>
-                <GridColumn xs={1}>
-                  <PaginationLink onClick={this.nextPage} disabled={!this.hasNextPage()} />
-                </GridColumn>
-              </Grid>
-            </div>
-          ) : data.map(this.renderLeader)}
+          {pageSize ? this.paginateLeaderboard() : data.map(this.renderLeader)}
         </LeaderboardWrapper>
+        {pageSize && (
+          <Grid justify={'center'}>
+            <GridColumn xs={1}>
+              <PaginationLink onClick={this.prevPage} rotate={180} disabled={currentPage <= 1} />
+            </GridColumn>
+            <GridColumn xs={1}>
+              <PaginationLink onClick={this.nextPage} disabled={!this.hasNextPage()} />
+            </GridColumn>
+          </Grid>
+        )}
       </div>
     )
   }


### PR DESCRIPTION
**Problem**

When displaying the leaderboard in columns, the pagination buttons would appear in the last column, as they were inside the LeaderboardWrapper component, which is where the css columns are applied.

**Solution**

Move them out of the LeaderboardWrapper component so they appear centred, even when in columns.