### PR TITLE
Center pagination buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/components/leaderboard/index.js
+++ b/source/components/leaderboard/index.js
@@ -5,7 +5,6 @@ import Filter from 'constructicon/filter'
 import LeaderboardWrapper from 'constructicon/leaderboard'
 import LeaderboardItem from 'constructicon/leaderboard-item'
 import Grid from 'constructicon/grid'
-import GridColumn from 'constructicon/grid-column'
 import PaginationLink from './pagination-link'
 
 import {
@@ -136,12 +135,8 @@ class Leaderboard extends Component {
         </LeaderboardWrapper>
         {pageSize && (
           <Grid justify={'center'}>
-            <GridColumn xs={1}>
-              <PaginationLink onClick={this.prevPage} rotate={180} disabled={currentPage <= 1} />
-            </GridColumn>
-            <GridColumn xs={1}>
-              <PaginationLink onClick={this.nextPage} disabled={!this.hasNextPage()} />
-            </GridColumn>
+            <PaginationLink onClick={this.prevPage} rotate={180} disabled={currentPage <= 1} />
+            <PaginationLink onClick={this.nextPage} disabled={!this.hasNextPage()} />
           </Grid>
         )}
       </div>

--- a/source/components/leaderboard/pagination-link/index.js
+++ b/source/components/leaderboard/pagination-link/index.js
@@ -9,9 +9,11 @@ const PaginationLink = ({
   rotate,
   classNames
 }) => (
-  <button onClick={onClick} disabled={disabled} className={classNames.pagination}>
-    <Icon name='chevron' rotate={rotate} size={1} />
-  </button>
+  <div className={classNames.root}>
+    <button onClick={onClick} disabled={disabled} className={classNames.pagination}>
+      <Icon name='chevron' rotate={rotate} size={1} />
+    </button>
+  </div>
 )
 
 export default withStyles(styles)(PaginationLink)

--- a/source/components/leaderboard/pagination-link/styles.js
+++ b/source/components/leaderboard/pagination-link/styles.js
@@ -1,9 +1,18 @@
-export default (props) => {
+export default (props, traits) => {
   const {
     disabled
   } = props
 
+  const {
+    rhythm
+  } = traits
+
   return {
+    root: {
+      width: rhythm(2),
+      textAlign: 'center'
+    },
+
     pagination: {
       opacity: disabled ? '0.2 !important' : 1,
       pointerEvents: disabled ? 'none' : 'all'


### PR DESCRIPTION
**Problem**

Both pagination buttons were in a GridColumn, which has a fixed width. And both buttons were left aligned within that column, which meant overall, the buttons sat slightly to the left of center. Probably wouldn't have been obvious when the leaderboard is just a single column, but when the leaderboard is 2 columns, the pagination was noticably off center.

**Solution**

Remove the GridColumn wrappers as they aren't really necessary, and just put each button in a small div, and make the button center aligned within that div. 