### PR TITLE
 Add ability to provide form method for SSO link component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "1.5.10",
+  "version": "1.5.11",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "babel-preset-stage-0": "^6.22.0",
     "babel-register": "^6.22.0",
     "chai": "^3.5.0",
-    "constructicon": "^0.12.2",
+    "constructicon": "^0.13.14",
     "enzyme": "^2.8.2",
     "gh-pages": "^0.12.0",
     "gitbook-cli": "^2.3.0",
@@ -59,7 +59,7 @@
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {
-    "constructicon": "~0.10",
+    "constructicon": "~0.13",
     "react": "^15.4.2",
     "react-dom": "^15.4.2"
   },

--- a/source/components/single-sign-on-link/index.js
+++ b/source/components/single-sign-on-link/index.js
@@ -27,6 +27,7 @@ class SingleSignOnLink extends Component {
       token,
       pageURL,
       label,
+      method,
       supporterCreateSessionURL = `${getBaseURL()}/api/v2/authentication/sessions`,
       ...props
     } = this.props
@@ -34,7 +35,7 @@ class SingleSignOnLink extends Component {
     const { target } = this.state
 
     return token ? (
-      <form method='POST' action={supporterCreateSessionURL} target={target}>
+      <form method={method} action={supporterCreateSessionURL} target={target}>
         <input type='hidden' name='access_token' value={token} />
         <input type='hidden' name='return_to' value={pageURL} />
         <Button {...props} type='submit'>{label}</Button>
@@ -76,7 +77,8 @@ SingleSignOnLink.propTypes = {
 
 SingleSignOnLink.defaultProps = {
   label: 'My Fundraising Page',
-  target: '_self'
+  target: '_self',
+  method: 'POST'
 }
 
 export default SingleSignOnLink

--- a/yarn.lock
+++ b/yarn.lock
@@ -1618,9 +1618,9 @@ constants-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
 
-constructicon@^0.12.2:
-  version "0.12.3"
-  resolved "https://registry.yarnpkg.com/constructicon/-/constructicon-0.12.3.tgz#52b3876b273de7400c1d5466a76a34606becaba1"
+constructicon@^0.13.14:
+  version "0.13.14"
+  resolved "https://registry.yarnpkg.com/constructicon/-/constructicon-0.13.14.tgz#716343f0ff13d49f8530ed2fa2da2288584c507e"
   dependencies:
     cxsync "^1.0.9"
     lodash "^4.17.4"


### PR DESCRIPTION
By adding the ability to provide a `method` prop for the `SingleSignOnLink` component we can also provide a logout flow for the EDH platform, e.g.

```
<SingleSignOnLink
  method='DELETE'
  token={token}
  pageURL='https://google.com'
  label='Sign out'
/>
```

For backwards compatibility I didn't update the name of the `pageURL` prop, though I wanted to.... Perhaps in a future major/minor version bump.