### PR TITLE
JustGiving Page Search

### DIFF
--- a/source/api/donation-totals/justgiving/index.js
+++ b/source/api/donation-totals/justgiving/index.js
@@ -1,15 +1,15 @@
 import { get } from '../../../utils/client'
-import { required, dataSource } from '../../../utils/params'
+import { getShortName, getUID, required, dataSource } from '../../../utils/params'
 
 export const fetchDonationTotals = (params = required()) => {
   switch (dataSource(params)) {
     case 'event':
-      return get(`v1/event/${params.event}/leaderboard`)
+      return get(`v1/event/${getUID(params.event)}/leaderboard`)
     case 'charity':
       // No API method supports total funds raised for a charity
       return required()
     default:
-      return get(`v1/campaigns/${params.charity}/${params.campaign}`)
+      return get(`v1/campaigns/${getShortName(params.charity)}/${getShortName(params.campaign)}`)
   }
 }
 

--- a/source/api/leaderboard/justgiving/index.js
+++ b/source/api/leaderboard/justgiving/index.js
@@ -1,5 +1,5 @@
 import { get } from '../../../utils/client'
-import { required, dataSource } from '../../../utils/params'
+import { getShortName, getUID, required, dataSource } from '../../../utils/params'
 import compact from 'lodash/compact'
 import orderBy from 'lodash/orderBy'
 import range from 'lodash/range'
@@ -23,7 +23,7 @@ const currencySymbol = (code = 'GBP') => {
 export const fetchLeaderboard = (params = required()) => {
   switch (dataSource(params)) {
     case 'event':
-      return get(`/v1/event/${params.event}/leaderboard`).then((response) => (
+      return get(`/v1/event/${getUID(params.event)}/leaderboard`).then((response) => (
         response.pages.map((page) => ({
           ...page,
           raisedAmount: page.amount,
@@ -33,7 +33,7 @@ export const fetchLeaderboard = (params = required()) => {
         }))
       ))
     case 'charity':
-      return get(`/v1/charity/${params.charity}/leaderboard`).then((response) => (
+      return get(`/v1/charity/${getUID(params.charity)}/leaderboard`).then((response) => (
         response.pages.map((page) => ({
           ...page,
           raisedAmount: page.amount,
@@ -43,7 +43,7 @@ export const fetchLeaderboard = (params = required()) => {
         }))
       ))
     default:
-      const url = `/v1/campaigns/${params.charity}/${params.campaign}/pages`
+      const url = `/v1/campaigns/${getShortName(params.charity)}/${getShortName(params.campaign)}/pages`
       const pageSize = 100
       const pageLimit = 10
       const sort = (pages) => orderBy(pages, 'raisedAmount', 'desc')

--- a/source/api/pages-totals/justgiving/index.js
+++ b/source/api/pages-totals/justgiving/index.js
@@ -1,14 +1,14 @@
 import { get } from '../../../utils/client'
-import { required, dataSource } from '../../../utils/params'
+import { getShortName, getUID, required, dataSource } from '../../../utils/params'
 
 export const fetchPagesTotals = (params = required()) => {
   switch (dataSource(params)) {
     case 'event':
-      return get(`v1/event/${params.event}/pages`).then((response) => response.totalFundraisingPages)
+      return get(`v1/event/${getUID(params.event)}/pages`).then((response) => response.totalFundraisingPages)
     case 'charity':
       // No API method supports total number of pages for a charity
       return required()
     default:
-      return get(`v1/campaigns/${params.charity}/${params.campaign}/pages`).then((response) => response.totalFundraisingPages)
+      return get(`v1/campaigns/${getShortName(params.charity)}/${getShortName(params.campaign)}/pages`).then((response) => response.totalFundraisingPages)
   }
 }

--- a/source/api/pages/__tests__/create-page-test.js
+++ b/source/api/pages/__tests__/create-page-test.js
@@ -1,8 +1,8 @@
 import moxios from 'moxios'
-import { instance } from '../../../utils/client'
+import { instance, updateClient } from '../../../utils/client'
 import { createPage } from '..'
 
-describe ('Page | Create Page', () => {
+describe ('Create Page', () => {
   beforeEach (() => {
     moxios.install(instance)
   })
@@ -11,48 +11,67 @@ describe ('Page | Create Page', () => {
     moxios.uninstall(instance)
   })
 
-  it ('throws if no token is passed', () => {
-    const test = () => createPage({
-      bogus: 'data'
+  describe('Create EDH Page', () => {
+    it ('throws if no token is passed', () => {
+      const test = () => createPage({
+        bogus: 'data'
+      })
+      expect(test).to.throw
     })
-    expect(test).to.throw
+
+    it ('hits the supporter api with the correct url and data', (done) => {
+      createPage({
+        token: '012345abcdef',
+        campaignId: '1234',
+        name: 'Super Supporter',
+        birthday: '1970-01-02'
+      })
+
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent()
+        expect(request.url).to.contain('https://everydayhero.com/api/v2/pages?access_token=012345abcdef')
+        done()
+      })
+    })
+
+    it ('returns the expected params', (done) => {
+      const response = {
+        campaignId: '1234',
+        name: 'Super Supporter',
+        birthday: '1970-01-02'
+      }
+
+      createPage({
+        token: '012345abcdef',
+        campaignId: '1234',
+        name: 'Super Supporter',
+        birthday: '1970-01-02'
+      }).then((page) => {
+        expect(page).to.equal(response)
+        done()
+      })
+
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent()
+        request.respondWith({ response: response })
+      })
+    })
   })
 
-  it ('hits the supporter api with the correct url and data', (done) => {
-    createPage({
-      token: '012345abcdef',
-      campaignId: '1234',
-      name: 'Super Supporter',
-      birthday: '1970-01-02'
+  describe ('Create JG Page', () => {
+    beforeEach (() => {
+      updateClient({ baseURL: 'https://api.justgiving.com' })
     })
 
-    moxios.wait(() => {
-      const request = moxios.requests.mostRecent()
-      expect(request.url).to.contain('https://everydayhero.com/api/v2/pages?access_token=012345abcdef')
-      done()
-    })
-  })
-
-  it ('returns the expected params', (done) => {
-    const response = {
-      campaignId: '1234',
-      name: 'Super Supporter',
-      birthday: '1970-01-02'
-    }
-
-    createPage({
-      token: '012345abcdef',
-      campaignId: '1234',
-      name: 'Super Supporter',
-      birthday: '1970-01-02'
-    }).then((page) => {
-      expect(page).to.equal(response)
-      done()
+    afterEach (() => {
+      updateClient({ baseURL: 'https://everydayhero.com' })
     })
 
-    moxios.wait(() => {
-      const request = moxios.requests.mostRecent()
-      request.respondWith({ response: response })
+    it ('throws method not supported error', (done) => {
+      createPage({ foo: 'bar' }).catch((err) => {
+        expect(err).to.eql('This method is not supported for JustGiving')
+        done()
+      })
     })
   })
 })

--- a/source/api/pages/__tests__/fetch-test.js
+++ b/source/api/pages/__tests__/fetch-test.js
@@ -47,6 +47,16 @@ describe ('Fetch Pages', () => {
       })
     })
 
+    it ('uses the uid name as the param when an object is supplied', (done) => {
+      fetchPages({ campaign: { uid: 'UID', shortName: 'SHORT_NAME' } })
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent()
+        expect(request.url).to.contain('https://api.justgiving.com/v1/onesearch')
+        expect(request.url).to.contain('campaignId=UID')
+        done()
+      })
+    })
+
     it ('throws if no params are passed in', () => {
       const test = () => fetchPages()
       expect(test).to.throw

--- a/source/api/pages/__tests__/fetch-test.js
+++ b/source/api/pages/__tests__/fetch-test.js
@@ -1,6 +1,6 @@
 import moxios from 'moxios'
 import { fetchPages } from '..'
-import { instance } from '../../../utils/client'
+import { instance, updateClient } from '../../../utils/client'
 
 describe ('Fetch Pages', () => {
   beforeEach (() => {
@@ -11,18 +11,45 @@ describe ('Fetch Pages', () => {
     moxios.uninstall(instance)
   })
 
-  it ('uses the correct url to fetch pages', (done) => {
-    fetchPages({ campaign_id: 'au-6839' })
-    moxios.wait(() => {
-      const request = moxios.requests.mostRecent()
-      expect(request.url).to.contain('https://everydayhero.com/api/v2/search/pages')
-      expect(request.url).to.contain('campaign_id=au-6839')
-      done()
+  describe ('Fetch EDH Pages', () => {
+    it ('uses the correct url to fetch pages', (done) => {
+      fetchPages({ campaign_id: 'au-6839' })
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent()
+        expect(request.url).to.contain('https://everydayhero.com/api/v2/search/pages')
+        expect(request.url).to.contain('campaign_id=au-6839')
+        done()
+      })
+    })
+
+    it ('throws if no params are passed in', () => {
+      const test = () => fetchPages()
+      expect(test).to.throw
     })
   })
 
-  it ('throws if no params are passed in', () => {
-    const test = () => fetchPages()
-    expect(test).to.throw
+  describe ('Fetch JG Pages', () => {
+    beforeEach (() => {
+      updateClient({ baseURL: 'https://api.justgiving.com' })
+    })
+
+    afterEach (() => {
+      updateClient({ baseURL: 'https://everydayhero.com' })
+    })
+
+    it ('uses the correct url to fetch pages', (done) => {
+      fetchPages({ campaign: 'CAMPAIGN_ID' })
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent()
+        expect(request.url).to.contain('https://api.justgiving.com/v1/onesearch')
+        expect(request.url).to.contain('campaignId=CAMPAIGN_ID')
+        done()
+      })
+    })
+
+    it ('throws if no params are passed in', () => {
+      const test = () => fetchPages()
+      expect(test).to.throw
+    })
   })
 })

--- a/source/api/pages/__tests__/update-page-test.js
+++ b/source/api/pages/__tests__/update-page-test.js
@@ -1,5 +1,5 @@
 import moxios from 'moxios'
-import { instance } from '../../../utils/client'
+import { instance, updateClient } from '../../../utils/client'
 import { updatePage } from '..'
 
 describe ('Page | Update Page', () => {
@@ -11,48 +11,67 @@ describe ('Page | Update Page', () => {
     moxios.uninstall(instance)
   })
 
-  it ('throws if no token is passed', () => {
-    const test = () => updatePage(123, {
-      bogus: 'data'
+  describe ('Create EDH Page', () => {
+    it ('throws if no token is passed', () => {
+      const test = () => updatePage(123, {
+        bogus: 'data'
+      })
+      expect(test).to.throw
     })
-    expect(test).to.throw
+
+    it ('hits the supporter api with the correct url and data', (done) => {
+      updatePage(123, {
+        token: '012345abcdef',
+        campaignId: '1234',
+        name: 'Super Supporter',
+        birthday: '1970-01-02'
+      })
+
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent()
+        expect(request.url).to.contain('https://everydayhero.com/api/v2/pages/123?access_token=012345abcdef')
+        done()
+      })
+    })
+
+    it ('returns the expected params', (done) => {
+      const response = {
+        campaignId: '1234',
+        name: 'Super Supporter',
+        birthday: '1970-01-02'
+      }
+
+      updatePage(123, {
+        token: '012345abcdef',
+        campaignId: '1234',
+        name: 'Super Supporter',
+        birthday: '1970-01-02'
+      }).then((page) => {
+        expect(page).to.equal(response)
+        done()
+      })
+
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent()
+        request.respondWith({ response: response })
+      })
+    })
   })
 
-  it ('hits the supporter api with the correct url and data', (done) => {
-    updatePage(123, {
-      token: '012345abcdef',
-      campaignId: '1234',
-      name: 'Super Supporter',
-      birthday: '1970-01-02'
+  describe ('Create JG Page', () => {
+    beforeEach (() => {
+      updateClient({ baseURL: 'https://api.justgiving.com' })
     })
 
-    moxios.wait(() => {
-      const request = moxios.requests.mostRecent()
-      expect(request.url).to.contain('https://everydayhero.com/api/v2/pages/123?access_token=012345abcdef')
-      done()
-    })
-  })
-
-  it ('returns the expected params', (done) => {
-    const response = {
-      campaignId: '1234',
-      name: 'Super Supporter',
-      birthday: '1970-01-02'
-    }
-
-    updatePage(123, {
-      token: '012345abcdef',
-      campaignId: '1234',
-      name: 'Super Supporter',
-      birthday: '1970-01-02'
-    }).then((page) => {
-      expect(page).to.equal(response)
-      done()
+    afterEach (() => {
+      updateClient({ baseURL: 'https://everydayhero.com' })
     })
 
-    moxios.wait(() => {
-      const request = moxios.requests.mostRecent()
-      request.respondWith({ response: response })
+    it ('throws method not supported error', (done) => {
+      updatePage(123, { foo: 'bar' }).catch((err) => {
+        expect(err).to.eql('This method is not supported for JustGiving')
+        done()
+      })
     })
   })
 })

--- a/source/api/pages/everydayhero/index.js
+++ b/source/api/pages/everydayhero/index.js
@@ -1,0 +1,99 @@
+import { get, post, put } from '../../../utils/client'
+import { required } from '../../../utils/params'
+
+/**
+* @function deserializer for supporter pages
+*/
+export const deserializePage = (page) => ({
+  active: page.active,
+  campaign: page.campaign || page.campaign_name,
+  campaignDate: page.campaign_date,
+  charity: page.charity || page.charity_name,
+  coordinates: page.coordinate,
+  donatationUrl: page.donation_url,
+  expired: page.expired,
+  groups: page.page_groups,
+  id: page.id,
+  image: page.image.medium_image_url,
+  name: page.name,
+  raised: page.amount.cents,
+  story: page.story,
+  target: page.target_cents,
+  teamPageId: page.team_page_id,
+  url: page.url,
+  uuid: page.uuid
+})
+
+/**
+* @function fetches pages from the supporter api
+*/
+export const fetchPages = (params = required()) => {
+  return get('api/v2/search/pages', params)
+    .then((response) => response.pages)
+}
+
+/**
+ * @function create page from the supporter api
+ */
+export const createPage = ({
+  token = required(),
+  campaignId = required(),
+  birthday = required(),
+  name,
+  target,
+  nickname,
+  slug,
+  image,
+  charityId,
+  expiresAt,
+  fitnessGoal,
+  campaignDate,
+  groupValues,
+  skipNotification,
+  inviteToken
+}) => {
+  return post(`/api/v2/pages?access_token=${token}`, {
+    campaign_id: campaignId,
+    birthday,
+    name,
+    target,
+    nickname,
+    slug,
+    image,
+    charity_id: charityId,
+    expires_at: expiresAt,
+    fitness_goal: fitnessGoal,
+    campaign_date: campaignDate,
+    group_values: groupValues,
+    skip_notification: skipNotification,
+    token: inviteToken
+  })
+}
+
+/**
+ * @function update page from the supporter api
+ */
+export const updatePage = (pageId, {
+  token = required(),
+  name,
+  target,
+  slug,
+  story,
+  image,
+  expiresAt,
+  fitnessGoal,
+  campaignDate,
+  groupValues
+}) => {
+  return put(`/api/v2/pages/${pageId}?access_token=${token}`, {
+    name,
+    target,
+    slug,
+    story,
+    image,
+    expires_at: expiresAt,
+    fitness_goal: fitnessGoal,
+    campaign_date: campaignDate,
+    group_values: groupValues
+  })
+}

--- a/source/api/pages/index.js
+++ b/source/api/pages/index.js
@@ -1,110 +1,51 @@
-import { get, post, put, isJustGiving } from '../../utils/client'
-import { required } from '../../utils/params'
+import { isJustGiving } from '../../utils/client'
 
-const c = {
-  SEARCH_ENDPOINT: 'api/v2/search/pages',
-  ENDPOINT: '/api/v2/pages'
-}
+import {
+  deserializePage as deserializeEDHPage,
+  fetchPages as fetchEDHPages,
+  createPage as createEDHPage,
+  updatePage as updateEDHPage
+} from './everydayhero'
+
+import {
+  deserializePage as deserializeJGPage,
+  fetchPages as fetchJGPages,
+  createPage as createJGPage,
+  updatePage as updateJGPage
+} from './justgiving'
 
 /**
 * @function deserializer for supporter pages
 */
-export const deserializePage = (page) => ({
-  active: page.active,
-  campaign: page.campaign || page.campaign_name,
-  campaignDate: page.campaign_date,
-  charity: page.charity || page.charity_name,
-  coordinates: page.coordinate,
-  donatationUrl: page.donation_url,
-  expired: page.expired,
-  groups: page.page_groups,
-  id: page.id,
-  image: page.image.medium_image_url,
-  name: page.name,
-  raised: page.amount.cents,
-  story: page.story,
-  target: page.target_cents,
-  teamPageId: page.team_page_id,
-  url: page.url,
-  uuid: page.uuid
-})
+export const deserializePage = (page) => (
+  isJustGiving()
+    ? deserializeJGPage(page)
+    : deserializeEDHPage(page)
+)
 
 /**
 * @function fetches pages from the supporter api
 */
-export const fetchPages = (params = required()) => {
-  if (isJustGiving()) return Promise.reject('This method is not supported for JustGiving')
-
-  return get(c.SEARCH_ENDPOINT, params)
-    .then((response) => response.pages)
-}
+export const fetchPages = (page) => (
+  isJustGiving()
+    ? fetchJGPages(page)
+    : fetchEDHPages(page)
+)
 
 /**
  * @function create page from the supporter api
  */
-export const createPage = ({
-  token = required(),
-  campaignId = required(),
-  birthday = required(),
-  name,
-  target,
-  nickname,
-  slug,
-  image,
-  charityId,
-  expiresAt,
-  fitnessGoal,
-  campaignDate,
-  groupValues,
-  skipNotification,
-  inviteToken
-}) => {
-  if (isJustGiving()) return Promise.reject('This method is not supported for JustGiving')
-
-  return post(`${c.ENDPOINT}?access_token=${token}`, {
-    campaign_id: campaignId,
-    birthday,
-    name,
-    target,
-    nickname,
-    slug,
-    image,
-    charity_id: charityId,
-    expires_at: expiresAt,
-    fitness_goal: fitnessGoal,
-    campaign_date: campaignDate,
-    group_values: groupValues,
-    skip_notification: skipNotification,
-    token: inviteToken
-  })
-}
+export const createPage = (params) => (
+  isJustGiving()
+    ? createJGPage(params)
+    : createEDHPage(params)
+)
 
 /**
  * @function update page from the supporter api
  */
-export const updatePage = (pageId, {
-  token = required(),
-  name,
-  target,
-  slug,
-  story,
-  image,
-  expiresAt,
-  fitnessGoal,
-  campaignDate,
-  groupValues
-}) => {
-  if (isJustGiving()) return Promise.reject('This method is not supported for JustGiving')
-
-  return put(`${c.ENDPOINT}/${pageId}?access_token=${token}`, {
-    name,
-    target,
-    slug,
-    story,
-    image,
-    expires_at: expiresAt,
-    fitness_goal: fitnessGoal,
-    campaign_date: campaignDate,
-    group_values: groupValues
-  })
-}
+export const updatePage = (pageId, params) => (
+  isJustGiving()
+    ? updateJGPage(pageId, params)
+    : updateEDHPage(pageId, params)
+)

--- a/source/api/pages/justgiving/index.js
+++ b/source/api/pages/justgiving/index.js
@@ -1,0 +1,56 @@
+import { get } from '../../../utils/client'
+import { required } from '../../../utils/params'
+
+/**
+* @function deserializer for supporter pages
+*/
+export const deserializePage = (page) => ({
+  active: null,
+  campaign: null,
+  campaignDate: null,
+  charity: null,
+  coordinates: null,
+  donatationUrl: null,
+  expired: null,
+  groups: null,
+  id: page.Id,
+  image: page.Logo,
+  name: page.Name,
+  raised: page.Amount,
+  story: page.ProfileWhy,
+  target: page.TargetAmount,
+  teamPageId: null,
+  url: page.Link,
+  uuid: null
+})
+
+/**
+* @function fetches pages from the supporter api
+*/
+export const fetchPages = (params = required()) => {
+  return get('/v1/onesearch', {
+    campaignId: params.campaign,
+    charityId: params.charity,
+    eventId: params.event,
+    i: 'Fundraiser',
+    ...params
+  }).then((response) => (
+    response.GroupedResults &&
+    response.GroupedResults.length &&
+    response.GroupedResults[0].Results
+  ))
+}
+
+/**
+ * @function create page from the supporter api
+ */
+export const createPage = (params) => {
+  return Promise.reject('This method is not supported for JustGiving')
+}
+
+/**
+ * @function update page from the supporter api
+ */
+export const updatePage = (pageId, params) => {
+  return Promise.reject('This method is not supported for JustGiving')
+}

--- a/source/api/pages/justgiving/index.js
+++ b/source/api/pages/justgiving/index.js
@@ -1,5 +1,5 @@
 import { get } from '../../../utils/client'
-import { required } from '../../../utils/params'
+import { getUID, required } from '../../../utils/params'
 
 /**
 * @function deserializer for supporter pages
@@ -28,16 +28,23 @@ export const deserializePage = (page) => ({
 * @function fetches pages from the supporter api
 */
 export const fetchPages = (params = required()) => {
+  const {
+    campaign,
+    charity,
+    event,
+    ...args
+  } = params
+
   return get('/v1/onesearch', {
-    campaignId: params.campaign,
-    charityId: params.charity,
-    eventId: params.event,
+    campaignId: getUID(campaign),
+    charityId: getUID(charity),
+    eventId: getUID(event),
     i: 'Fundraiser',
-    ...params
+    ...args
   }).then((response) => (
     response.GroupedResults &&
     response.GroupedResults.length &&
-    response.GroupedResults[0].Results
+    response.GroupedResults[0].Results || []
   ))
 }
 

--- a/source/components/page-search/Readme.md
+++ b/source/components/page-search/Readme.md
@@ -5,3 +5,11 @@
   campaign='au-21638'
 />
 ```
+
+### JustGiving
+
+```
+<PageSearch
+  event='4111382'
+/>
+```

--- a/source/components/page-search/index.js
+++ b/source/components/page-search/index.js
@@ -37,6 +37,7 @@ class PageSearch extends Component {
       q: query,
       campaign: this.props.campaign,
       charity: this.props.charity,
+      event: this.props.event,
       type: this.props.type,
       group: this.props.group,
       limit: this.props.limit,
@@ -74,6 +75,8 @@ class PageSearch extends Component {
       data = []
     } = this.state
 
+    console.log(data)
+
     return (
       <SearchResults
         loading={status === 'fetching'}
@@ -84,7 +87,7 @@ class PageSearch extends Component {
           <SearchResult
             key={i}
             title={page.name}
-            subtitle={page.charity.name}
+            subtitle={page.charity && page.charity.name}
             image={page.image}
             url={page.url}
             {...this.props.searchResult}
@@ -111,6 +114,11 @@ PageSearch.propTypes = {
     PropTypes.string,
     PropTypes.array
   ]),
+
+  /**
+  * The event id
+  */
+  event: PropTypes.string,
 
   /**
   * The type of page to include in the leaderboard

--- a/source/components/page-search/index.js
+++ b/source/components/page-search/index.js
@@ -75,8 +75,6 @@ class PageSearch extends Component {
       data = []
     } = this.state
 
-    console.log(data)
-
     return (
       <SearchResults
         loading={status === 'fetching'}

--- a/source/utils/params/index.js
+++ b/source/utils/params/index.js
@@ -4,13 +4,13 @@ export const required = () => {
 
 export const dataSource = ({ event, charity, campaign }) => {
   if (event) {
-    if (isNaN(event)) {
+    if (isNaN(event) && isNaN(event.uid)) {
       throw new Error('Event parameter must be an ID')
     }
 
     return 'event'
   } else if (charity && !campaign) {
-    if (isNaN(charity)) {
+    if (isNaN(charity) && isNaN(charity.uid)) {
       throw new Error('Charity parameter must be an ID')
     }
 
@@ -23,3 +23,11 @@ export const dataSource = ({ event, charity, campaign }) => {
     return 'campaign'
   }
 }
+
+export const getUID = (data) => (
+  typeof data === 'object' ? data.uid : data
+)
+
+export const getShortName = (data) => (
+  typeof data === 'object' ? data.shortName : data
+)


### PR DESCRIPTION
- Add support for searching JustGiving pages
- For campaign/charity/event, accept either a string or an object containing uid and short name, as different endpoints require either the uid or the short name, and this way we can just pass them both in and let supporticon worry about which to use
