### PR TITLE
Check env vars for defaulting the base url

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/utils/client/index.js
+++ b/source/utils/client/index.js
@@ -3,7 +3,7 @@ import { required } from '../params'
 import map from '../map'
 
 const defaults = {
-  baseURL: 'https://everydayhero.com'
+  baseURL: process.env.SUPPORTICON_BASE_URL || 'https://everydayhero.com'
 }
 
 export const instance = axios.create(defaults)


### PR DESCRIPTION
**Problem**

In our projects, we have to do something like this in both `client.js` and `server.js`

```
import { updateClient } from 'supporticon/utils/client'

updateClient({ baseURL: process.env.SUPPORTER_URL })
```

**Solution**

Now we can set the baseURL using an env var called `SUPPORTICON_BASE_URL`, and avoid having to override it manually.

If not found, it will still fall back `https://everydayhero.com`, and there is still the ability to update it using `updateClient`, as this is used in places like the site builder, where the API to talk to is set at runtime.