### PR TITLE
Add mapping to totals endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/donation-totals/everydayhero/index.js
+++ b/source/api/donation-totals/everydayhero/index.js
@@ -2,7 +2,11 @@ import { get } from '../../../utils/client'
 import { required } from '../../../utils/params'
 
 export const fetchDonationTotals = (params = required()) => {
-  return get('api/v2/search/totals', params)
+  const mappings = {
+    type: 'type'
+  }
+
+  return get('api/v2/search/totals', params, { mappings })
 }
 
 export const deserializeDonationTotals = (totals) => ({


### PR DESCRIPTION
Previously the [default mapping of `type` to `group_by`](https://github.com/everydayhero/supporticon/blob/master/source/utils/map/index.js#L5) made it impossible to set the param for this endpoint