### PR TITLE
Create page form component

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "babel-preset-stage-0": "^6.22.0",
     "babel-register": "^6.22.0",
     "chai": "^3.5.0",
-    "constructicon": "^1.5.2",
+    "constructicon": "^1.5.4",
     "enzyme": "^2.8.2",
     "gh-pages": "^0.12.0",
     "gitbook-cli": "^2.3.0",
@@ -59,7 +59,7 @@
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {
-    "constructicon": "~1.5",
+    "constructicon": "^1.5.4",
     "react": "^15.4.2",
     "react-dom": "^15.4.2"
   },

--- a/source/components/create-page-form/Readme.md
+++ b/source/components/create-page-form/Readme.md
@@ -1,0 +1,41 @@
+# Examples
+
+```
+<CreatePageForm
+  campaignId='au-0'
+  token='1234abcd'
+  onSuccess={(result) => alert(JSON.stringify(result))}
+/>
+```
+
+**With extra fields:**
+
+```
+const required = (msg = 'This field is required') => {
+  return (val) => {
+    switch (typeof val) {
+      case 'string':
+        return !val.trim() && msg
+      default:
+        return !val && msg
+    }
+  }
+};
+
+<CreatePageForm
+  campaignId='au-0'
+  token='1234abcd'
+  fields={{
+    target: {
+      label: 'Fundraising Target',
+      type: 'number',
+      placeholder: '500',
+      required: true,
+      validators: [
+        required('Please enter a target')
+      ]
+    }
+  }}
+  onSuccess={(result) => alert(JSON.stringify(result))}
+/>
+```

--- a/source/components/create-page-form/__tests__/create-page-form-test.js
+++ b/source/components/create-page-form/__tests__/create-page-form-test.js
@@ -1,0 +1,69 @@
+import React from 'react'
+import moxios from 'moxios'
+import { instance, updateClient } from '../../../utils/client'
+
+import CreatePageForm from '..'
+
+describe ('Components | CreatePageForm', () => {
+  describe ('EDH CreatePageForm', () => {
+    it ('renders a simple create page form', () => {
+      const wrapper = mount(<CreatePageForm country='au' clientId='1234abcd' onSuccess={(res) => console.log(res)} />)
+      const inputs = wrapper.find('input')
+      const button = wrapper.find('button')
+
+      expect(inputs.length).to.eql(1)
+      expect(button.length).to.eql(1)
+      expect(button.text()).to.eql('Create Page')
+    })
+
+    it ('allows a custom submit button label to be passed', () => {
+      const wrapper = mount(<CreatePageForm clientId='1234abcd' submit='Create Page on EDH' onSuccess={(res) => console.log(res)} />)
+      const button = wrapper.find('button')
+
+      expect(button.length).to.eql(1)
+      expect(button.text()).to.eql('Create Page on EDH')
+    })
+
+    it ('allows for custom fields to be passed', () => {
+      const wrapper = mount(<CreatePageForm clientId='1234abcd' fields={{ name: { type: 'text'} }} onSuccess={(res) => console.log(res)} />)
+      const inputs = wrapper.find('input')
+      expect(inputs.length).to.eql(2)
+    })
+  })
+
+  describe ('JG CreatePageForm', () => {
+    beforeEach (() => {
+      updateClient({ baseURL: 'https://api.justgiving.com', headers: { 'x-api-key': 'abcd1234' } })
+      moxios.install(instance)
+    })
+
+    afterEach (() => {
+      updateClient({ baseURL: 'https://everydayhero.com' })
+      moxios.uninstall(instance)
+    })
+
+    it ('renders a simple create page form with custom submit prop', () => {
+      const wrapper = mount(<CreatePageForm onSuccess={(res) => console.log(res)} />)
+      const inputs = wrapper.find('input')
+      const button = wrapper.find('button')
+
+      expect(inputs.length).to.eql(2)
+      expect(button.length).to.eql(1)
+      expect(button.text()).to.eql('Create Page')
+    })
+
+    it ('allows a custom submit button label to be passed', () => {
+      const wrapper = mount(<CreatePageForm submit='Create Page on JustGiving' onSuccess={(res) => console.log(res)} />)
+      const button = wrapper.find('button')
+
+      expect(button.length).to.eql(1)
+      expect(button.text()).to.eql('Create Page on JustGiving')
+    })
+
+    it ('allows for custom fields to be passed', () => {
+      const wrapper = mount(<CreatePageForm fields={{ name: { type: 'text'} }} onSuccess={(res) => console.log(res)} />)
+      const inputs = wrapper.find('input')
+      expect(inputs.length).to.eql(3)
+    })
+  })
+})

--- a/source/components/create-page-form/index.js
+++ b/source/components/create-page-form/index.js
@@ -1,0 +1,225 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import capitalize from 'lodash/capitalize'
+import get from 'lodash/get'
+import merge from 'lodash/merge'
+import values from 'lodash/values'
+import withForm from 'constructicon/with-form'
+import * as validators from 'constructicon/lib/validators'
+import { createPage } from '../../api/pages'
+import { isJustGiving } from '../../utils/client'
+
+import Form from 'constructicon/form'
+import InputDate from 'constructicon/input-date'
+import InputField from 'constructicon/input-field'
+
+class CreatePageForm extends Component {
+  constructor () {
+    super()
+    this.handleSubmit = this.handleSubmit.bind(this)
+    this.state = {
+      status: 'empty',
+      errors: []
+    }
+  }
+
+  handleSubmit (e) {
+    e.preventDefault()
+
+    const {
+      campaignId,
+      charityFunded,
+      charityId,
+      eventId,
+      form,
+      onSuccess,
+      token
+    } = this.props
+
+    return form.submit().then((data) => {
+      this.setState({
+        errors: [],
+        status: 'fetching'
+      })
+
+      const dataPayload = merge({
+        campaignId,
+        charityFunded,
+        charityId,
+        charityOptIn: true,
+        eventId,
+        token
+      }, data)
+
+      return createPage(dataPayload).then((result) => {
+        this.setState({ status: 'fetched' })
+
+        return onSuccess(result)
+      }).catch((error) => {
+        switch (error.status) {
+          case 422:
+            const errors = get(error, 'data.error.errors') || []
+
+            return this.setState({
+              status: 'failed',
+              errors: errors.map(({ field, message }) => ({ message: [capitalize(field), message].join(' ') }))
+            })
+          case 400:
+            const errorMessages = error.data || []
+
+            return this.setState({
+              status: 'failed',
+              errors: errorMessages.map(({ desc }) => ({ message: capitalize(desc) }))
+            })
+          default:
+            const message = get(error, 'data.error.message') || get(error, 'data.errorMessage')
+
+            return this.setState({
+              status: 'failed',
+              errors: message ? [{ message }] : []
+            })
+        }
+      })
+    })
+  }
+
+  render () {
+    const {
+      disableInvalidForm,
+      form,
+      formComponent,
+      inputField,
+      submit
+    } = this.props
+
+    const {
+      status,
+      errors
+    } = this.state
+
+    return (
+      <Form
+        errors={errors}
+        isDisabled={disableInvalidForm && form.invalid}
+        isLoading={status === 'fetching'}
+        noValidate
+        onSubmit={this.handleSubmit}
+        submit={submit}
+        autoComplete='off'
+        {...formComponent}>
+
+        {values(form.fields).map((field) => {
+          const Tag = field.type === 'date' ? InputDate : InputField
+          return <Tag key={field.name} {...field} {...inputField} />
+        })}
+      </Form>
+    )
+  }
+}
+
+CreatePageForm.propTypes = {
+  /**
+  * The campaignId for a valid campaign (EDH only - required)
+  */
+  campaignId: PropTypes.string,
+
+  /**
+  * The charityId for a valid charity (Required for JG)
+  */
+  charityId: PropTypes.string,
+
+  /**
+  * Whether Gift Aid is enabled
+  */
+  charityFunded: PropTypes.bool,
+
+  /**
+  * Disable form submission when invalid
+  */
+  disableInvalidForm: PropTypes.bool,
+
+  /**
+  * The eventId for a valid event (JG only - required)
+  */
+  eventId: PropTypes.string,
+
+  /**
+  * Form fields to be passed to withForm config
+  */
+  fields: PropTypes.object,
+
+  /**
+  * Props to be passed to the Form component
+  */
+  formComponent: PropTypes.object,
+
+  /**
+  * Props to be passed to the InputField components
+  */
+  inputField: PropTypes.object,
+
+  /**
+  * The onSuccess event handler
+  */
+  onSuccess: PropTypes.func.isRequired,
+
+  /**
+  * The label for the form submit button
+  */
+  submit: PropTypes.string,
+
+  /**
+  * The logged in users' auth token
+  */
+  token: PropTypes.string.isRequired
+}
+
+CreatePageForm.defaultProps = {
+  charityFunded: false,
+  disableInvalidForm: false,
+  submit: 'Create Page'
+}
+
+const isValidSlug = (msg = 'No special characters allowed') => {
+  return (val) => !!val && !/^[A-Za-z0-9_+-]+$/i.test(val) && msg
+}
+
+const form = (props) => ({
+  fields: merge(isJustGiving() ? {
+    title: {
+      label: 'Page title',
+      type: 'text',
+      required: true,
+      maxLength: 255,
+      placeholder: 'Title of your fundraising page',
+      validators: [
+        validators.required('Please enter a page title')
+      ]
+    },
+    slug: {
+      label: 'Page URL',
+      type: 'text',
+      required: true,
+      maxLength: 255,
+      placeholder: 'URL for your fundraising page',
+      validators: [
+        validators.required('Please enter your page URL'),
+        isValidSlug('Please enter a valid URL')
+      ]
+    }
+  } : {
+    birthday: {
+      label: 'Date of birth',
+      type: 'date',
+      required: true,
+      placeholder: 'DD/MM/YYYY',
+      min: '1900-01-01',
+      pattern: '[0-9]{4}-[0-9]{2}-[0-9]{2}',
+      validators: [
+        validators.required('Please enter your date of birth')
+      ]
+    }
+  }, props.fields)
+})
+
+export default withForm(form)(CreatePageForm)

--- a/source/components/create-page-form/index.js
+++ b/source/components/create-page-form/index.js
@@ -180,10 +180,6 @@ CreatePageForm.defaultProps = {
   submit: 'Create Page'
 }
 
-const isValidSlug = (msg = 'No special characters allowed') => {
-  return (val) => !!val && !/^[A-Za-z0-9_+-]+$/i.test(val) && msg
-}
-
 const form = (props) => ({
   fields: merge(isJustGiving() ? {
     title: {
@@ -202,9 +198,10 @@ const form = (props) => ({
       required: true,
       maxLength: 255,
       placeholder: 'URL for your fundraising page',
+      onKeyDown: (e) => e.which === 32 && e.preventDefault(),
       validators: [
         validators.required('Please enter your page URL'),
-        isValidSlug('Please enter a valid URL')
+        validators.slug('Please enter a valid URL using only letters, numbers or hyphens (-)')
       ]
     }
   } : {

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -35,6 +35,7 @@ module.exports = {
     {
       name: 'Authentication',
       components: () => ([
+        path.resolve(__dirname, 'source/components/create-page-form', 'index.js'),
         path.resolve(__dirname, 'source/components/login-form', 'index.js'),
         path.resolve(__dirname, 'source/components/reset-password-form', 'index.js'),
         path.resolve(__dirname, 'source/components/signup-form', 'index.js'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1618,9 +1618,9 @@ constants-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
 
-constructicon@^1.4.4:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/constructicon/-/constructicon-1.4.4.tgz#03e699efc27ffbadd09fdf47c4a92d5795aa4399"
+constructicon@^1.5.4:
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/constructicon/-/constructicon-1.5.4.tgz#ab944578067f4095b01ded092861e9805b1c80bf"
   dependencies:
     cxsync "^1.0.9"
     lodash "^4.17.4"
@@ -1629,6 +1629,7 @@ constructicon@^1.4.4:
     prop-types "^15.5.8"
     react-helmet "^5.1.3"
     react-modal "^1.9.4"
+    react-onclickoutside "^6.7.1"
     react-slick "0.14.11"
 
 content-disposition@0.5.1:
@@ -5621,6 +5622,10 @@ react-modal@^1.9.4:
     exenv "1.2.0"
     lodash.assign "^4.2.0"
     prop-types "^15.5.7"
+
+react-onclickoutside@^6.7.1:
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.7.1.tgz#6a5b5b8b4eae6b776259712c89c8a2b36b17be93"
 
 react-prefixer@^1.1.4:
   version "1.1.4"


### PR DESCRIPTION
This provides an basic working version of a form component for creating pages in either EDH or JG.

If the required `props` for either environment are passed to the component, the minimum required fields will display for the user.

Additional fields can be added through the `fields` prop, which are passed into the `withForm` config

![screen](https://user-images.githubusercontent.com/729085/37068105-c761503c-21f8-11e8-928a-c7bc0697f9f2.png)

**N.B. Increased support to come in future PRs (e.g. additional props to include specific fields, EDH groups fetch, check JG slug availability)**