### PR TITLE
Group leaderboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "babel-preset-stage-0": "^6.22.0",
     "babel-register": "^6.22.0",
     "chai": "^3.5.0",
-    "constructicon": "^1.5.4",
+    "constructicon": "^1.5.5",
     "enzyme": "^2.8.2",
     "gh-pages": "^0.12.0",
     "gitbook-cli": "^2.3.0",

--- a/source/api/fitness-leaderboard/__tests__/fetch-test.js
+++ b/source/api/fitness-leaderboard/__tests__/fetch-test.js
@@ -88,4 +88,15 @@ describe ('Fetch Fitness Leaderboards', () => {
       done()
     })
   })
+
+  it ('fetches leaderboards based on a group', (done) => {
+    fetchFitnessLeaderboard({ type: 'group', groupID: 99 })
+    moxios.wait(function () {
+      const request = moxios.requests.mostRecent()
+      expect(request.url).to.contain('https://everydayhero.com/api/v2/search/fitness_activities_totals')
+      expect(request.url).to.contain('group_by=groups')
+      expect(request.url).to.contain('group_id=99')
+      done()
+    })
+  })
 })

--- a/source/api/leaderboard/__tests__/fetch-test.js
+++ b/source/api/leaderboard/__tests__/fetch-test.js
@@ -86,6 +86,17 @@ describe ('Fetch Leaderboards', () => {
         done()
       })
     })
+
+    it ('fetches leaderboards based on a group', (done) => {
+      fetchEDHLeaderboard({ type: 'group', groupID: 99 })
+      moxios.wait(function () {
+        const request = moxios.requests.mostRecent()
+        expect(request.url).to.contain('https://everydayhero.com/api/v2/search/pages_total')
+        expect(request.url).to.contain('group_by=groups')
+        expect(request.url).to.contain('group_id=99')
+        done()
+      })
+    })
   })
 
   describe ('Fetch JG Leaderboards', () => {

--- a/source/api/leaderboard/everydayhero/index.js
+++ b/source/api/leaderboard/everydayhero/index.js
@@ -6,30 +6,51 @@ import { required } from '../../../utils/params'
 */
 export const fetchLeaderboard = (params = required()) => {
   const transforms = {
-    type: (val) => val === 'team' ? 'teams' : 'individuals'
+    type: (val) => val === 'team'
+      ? 'teams'
+      : val === 'group'
+        ? 'groups'
+        : 'individuals'
   }
 
-  return get('api/v2/search/pages_totals', params, { transforms })
+  const mappings = {
+    groupID: 'group_id'
+  }
+
+  return get('api/v2/search/pages_totals', params, { mappings, transforms })
     .then((response) => response.results)
 }
 
 /**
 * @function a default deserializer for leaderboard pages
 */
-export const deserializeLeaderboard = ({ page, team }, index) => {
-  const detail = team || page
-
-  return {
-    position: index + 1,
-    id: detail.id,
-    name: detail.name,
-    subtitle: detail.charity_name,
-    url: detail.url,
-    image: detail.image.medium_image_url,
-    raised: detail.amount.cents / 100,
-    target: detail.target_cents / 100,
-    currency: detail.amount.currency.iso_code,
-    currencySymbol: detail.amount.currency.symbol,
-    groups: detail.group_values
+export const deserializeLeaderboard = (result, index) => {
+  if (result.page) {
+    return deserializePage(result.page, index)
+  } else if (result.team) {
+    return deserializePage(result.team, index)
+  } else if (result.group) {
+    return deserializeGroup(result, index)
   }
 }
+
+const deserializePage = (item, index) => ({
+  position: index + 1,
+  id: item.id,
+  name: item.name,
+  subtitle: item.charity_name,
+  url: item.url,
+  image: item.image.medium_image_url,
+  raised: item.amount.cents / 100,
+  target: item.target_cents / 100,
+  currency: item.amount.currency.iso_code,
+  currencySymbol: item.amount.currency.symbol,
+  groups: item.group_values
+})
+
+const deserializeGroup = (item, index) => ({
+  count: item.count,
+  id: item.group.id,
+  name: item.group.value,
+  raised: item.amount_cents / 100
+})

--- a/source/api/leaderboard/everydayhero/index.js
+++ b/source/api/leaderboard/everydayhero/index.js
@@ -49,6 +49,7 @@ const deserializePage = (item, index) => ({
 })
 
 const deserializeGroup = (item, index) => ({
+  position: index + 1,
   count: item.count,
   id: item.group.id,
   name: item.group.value,

--- a/source/components/fitness-leaderboard/Readme.md
+++ b/source/components/fitness-leaderboard/Readme.md
@@ -1,7 +1,28 @@
 # Examples
 
+*Standard Use*
+
 ```
 <FitnessLeaderboard
   campaign='au-21638'
+/>
+```
+
+*Leaderboard by Team*
+
+```
+<FitnessLeaderboard
+  campaign='au-21937'
+  type='team'
+/>
+```
+
+*Leaderboard by Group*
+
+```
+<FitnessLeaderboard
+  campaign='au-21937'
+  type='group'
+  groupID={58}
 />
 ```

--- a/source/components/fitness-leaderboard/index.js
+++ b/source/components/fitness-leaderboard/index.js
@@ -43,7 +43,8 @@ class FitnessLeaderboard extends Component {
       includeManual,
       excludeVirtual,
       limit,
-      page
+      page,
+      groupID
     } = this.props
 
     this.setState({
@@ -62,6 +63,7 @@ class FitnessLeaderboard extends Component {
       exclude_virtual: excludeVirtual,
       limit,
       page,
+      groupID,
       q
     })
       .then((data) => {
@@ -144,7 +146,7 @@ FitnessLeaderboard.propTypes = {
   /**
   * The type of page to include in the leaderboard
   */
-  type: PropTypes.oneOf([ 'individual', 'team' ]),
+  type: PropTypes.oneOf([ 'group', 'individual', 'team' ]),
 
   /**
   * The activity type of page to include in the leaderboard (bike, gym, hike, run, sport, swim, walk)
@@ -201,6 +203,11 @@ FitnessLeaderboard.propTypes = {
   * The page to fetch
   */
   page: PropTypes.number,
+
+  /**
+  * The group ID to group the leaderboard by (only relevant if type is group)
+  */
+  groupID: PropTypes.number,
 
   /**
   * Props to be passed to the Constructicon Leaderboard component

--- a/source/components/leaderboard/Readme.md
+++ b/source/components/leaderboard/Readme.md
@@ -16,3 +16,22 @@
   pageSize={10}
 />
 ```
+
+*Leaderboard by Team*
+
+```
+<Leaderboard
+  campaign='au-21937'
+  type='team'
+/>
+```
+
+*Leaderboard by Group*
+
+```
+<Leaderboard
+  campaign='au-21937'
+  type='group'
+  groupID={58}
+/>
+```

--- a/source/components/leaderboard/index.js
+++ b/source/components/leaderboard/index.js
@@ -185,7 +185,7 @@ Leaderboard.propTypes = {
   /**
   * The type of page to include in the leaderboard
   */
-  type: PropTypes.oneOf([ 'individual', 'group', 'team' ]),
+  type: PropTypes.oneOf([ 'group', 'individual', 'team' ]),
 
   /**
   * The group value(s) to filter by

--- a/source/components/leaderboard/index.js
+++ b/source/components/leaderboard/index.js
@@ -79,7 +79,8 @@ class Leaderboard extends Component {
       startDate,
       endDate,
       limit,
-      page
+      page,
+      groupID
     } = this.props
 
     this.setState({
@@ -97,6 +98,7 @@ class Leaderboard extends Component {
       endDate,
       limit,
       page,
+      groupID,
       q
     })
       .then((data) => {
@@ -183,7 +185,7 @@ Leaderboard.propTypes = {
   /**
   * The type of page to include in the leaderboard
   */
-  type: PropTypes.oneOf([ 'individual', 'team' ]),
+  type: PropTypes.oneOf([ 'individual', 'group', 'team' ]),
 
   /**
   * The group value(s) to filter by
@@ -217,6 +219,11 @@ Leaderboard.propTypes = {
   * The page to fetch
   */
   page: PropTypes.number,
+
+  /**
+  * The group ID to group the leaderboard by (only relevant if type is group)
+  */
+  groupID: PropTypes.number,
 
   /**
   * Props to be passed to the Constructicon Leaderboard component

--- a/yarn.lock
+++ b/yarn.lock
@@ -189,9 +189,13 @@ arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
-asap@^2.0.0, asap@~2.0.3:
+asap@^2.0.0:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.5.tgz#522765b50c3510490e52d7dcfe085ef9ba96958f"
+
+asap@~2.0.3:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
 asn1.js@^4.0.0:
   version "4.9.1"
@@ -1146,8 +1150,8 @@ boom@2.x.x:
     hoek "2.x.x"
 
 bowser@^1.0.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.6.0.tgz#37fc387b616cb6aef370dab4d6bd402b74c5c54d"
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.9.2.tgz#d66fc868ca5f4ba895bee1363c343fe7b37d3394"
 
 brace-expansion@^1.0.0:
   version "1.1.6"
@@ -1618,9 +1622,9 @@ constants-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
 
-constructicon@^1.5.4:
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/constructicon/-/constructicon-1.5.4.tgz#ab944578067f4095b01ded092861e9805b1c80bf"
+constructicon@^1.5.5:
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/constructicon/-/constructicon-1.5.5.tgz#56bf89fdbcc3c5a1f0566df15a7e2b0182479d85"
   dependencies:
     cxsync "^1.0.9"
     lodash "^4.17.4"
@@ -1692,8 +1696,8 @@ create-hmac@^1.1.0, create-hmac@^1.1.2:
     inherits "^2.0.1"
 
 create-react-class@^15.5.2:
-  version "15.5.3"
-  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.5.3.tgz#fb0f7cae79339e9a179e194ef466efa3923820fe"
+  version "15.6.3"
+  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.3.tgz#2d73237fb3f970ae6ebe011a9e66f46dbca80036"
   dependencies:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
@@ -2461,9 +2465,21 @@ fastparse@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.1.tgz#d1e2643b38a94d7583b479060e6c4affc94071f8"
 
-fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.9:
+fbjs@^0.8.1, fbjs@^0.8.4:
   version "0.8.9"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.9.tgz#180247fbd347dcc9004517b904f865400a0c8f14"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
+
+fbjs@^0.8.16, fbjs@^0.8.9:
+  version "0.8.16"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
     core-js "^1.0.0"
     isomorphic-fetch "^2.1.1"
@@ -3196,9 +3212,13 @@ hyphenate-style-name@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
 
-iconv-lite@0.4.13, iconv-lite@~0.4.13:
+iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
+
+iconv-lite@~0.4.13:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
 icss-replace-symbols@^1.0.2:
   version "1.0.2"
@@ -3557,17 +3577,13 @@ jodid25519@^1.0.0:
   dependencies:
     jsbn "~0.1.0"
 
-jquery@>=1.7.2:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.1.1.tgz#347c1c21c7e004115e0a4da32cece041fad3c8a3"
-
 js-base64@^2.1.9:
   version "2.1.9"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.1.9.tgz#f0e80ae039a4bd654b5f281fc93f04a914a7fcce"
 
 js-tokens@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
 js-yaml@^3.5.1:
   version "3.8.1"
@@ -4186,9 +4202,13 @@ lodash@4.5.1:
   version "4.5.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.5.1.tgz#80e8a074ca5f3893a6b1c10b2a636492d710c316"
 
-lodash@^4.0.0, lodash@^4.14.0, lodash@^4.16.4, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
+lodash@^4.16.4:
+  version "4.17.5"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
 lodash@~1.0.1:
   version "1.0.2"
@@ -4394,8 +4414,8 @@ mocha@^3.2.0:
     supports-color "3.1.2"
 
 moment@^2.19.1:
-  version "2.20.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.20.1.tgz#d6eb1a46cbcc14a2b2f9434112c1ff8907f313fd"
+  version "2.21.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.21.0.tgz#2a114b51d2a6ec9e6d83cf803f838a878d8a023a"
 
 moxios@^0.4.0:
   version "0.4.0"
@@ -4458,8 +4478,8 @@ node-dir@^0.1.10:
     minimatch "^3.0.2"
 
 node-fetch@^1.0.1:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.6.3.tgz#dc234edd6489982d58e8f0db4f695029abcd8c04"
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
@@ -5435,8 +5455,8 @@ progress@^1.1.8:
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
 
 promise@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
   dependencies:
     asap "~2.0.3"
 
@@ -5446,7 +5466,15 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8:
+prop-types@^15.5.4, prop-types@^15.5.7:
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
+prop-types@^15.5.8:
   version "15.5.8"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
   dependencies:
@@ -5592,6 +5620,10 @@ react-docgen@^2.13.0:
     node-dir "^0.1.10"
     recast "^0.11.5"
 
+react-dom-factories@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/react-dom-factories/-/react-dom-factories-1.0.2.tgz#eb7705c4db36fb501b3aa38ff759616aa0ff96e0"
+
 react-dom@^15.4.2:
   version "15.4.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.4.2.tgz#015363f05b0a1fd52ae9efdd3a0060d90695208f"
@@ -5614,14 +5646,15 @@ react-helmet@^5.1.3:
     react-side-effect "^1.1.0"
 
 react-modal@^1.9.4:
-  version "1.9.4"
-  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-1.9.4.tgz#f6823c29ca9ecbecd9cc2a9f019e78e4319bafdd"
+  version "1.9.7"
+  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-1.9.7.tgz#07ef56790b953e3b98ef1e2989e347983c72871d"
   dependencies:
     create-react-class "^15.5.2"
     element-class "^0.2.0"
     exenv "1.2.0"
     lodash.assign "^4.2.0"
     prop-types "^15.5.7"
+    react-dom-factories "^1.0.0"
 
 react-onclickoutside@^6.7.1:
   version "6.7.1"
@@ -5632,8 +5665,8 @@ react-prefixer@^1.1.4:
   resolved "https://registry.yarnpkg.com/react-prefixer/-/react-prefixer-1.1.4.tgz#e32a01c8c0dbb0f918ccd428a94932a943abf24b"
 
 react-side-effect@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-1.1.3.tgz#512c25abe0dec172834c4001ec5c51e04d41bc5c"
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-1.1.5.tgz#f26059e50ed9c626d91d661b9f3c8bb38cd0ff2d"
   dependencies:
     exenv "^1.2.1"
     shallowequal "^1.0.1"
@@ -6323,10 +6356,8 @@ slice-ansi@0.0.4:
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
 
 slick-carousel@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/slick-carousel/-/slick-carousel-1.6.0.tgz#780f378e470f4e6f6bec1aa2bae0475f4f9eb085"
-  dependencies:
-    jquery ">=1.7.2"
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/slick-carousel/-/slick-carousel-1.8.1.tgz#a4bfb29014887bb66ce528b90bd0cda262cc8f8d"
 
 slide@^1.1.3, slide@^1.1.5, slide@~1.1.3, slide@~1.1.6:
   version "1.1.6"
@@ -6731,8 +6762,8 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
 ua-parser-js@^0.7.9:
-  version "0.7.12"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"
+  version "0.7.17"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
 
 uglify-js@2.7.x, uglify-js@^2.7.5:
   version "2.7.5"


### PR DESCRIPTION
Added support for group leaderboards for both fundraising and fitness leaderboards.

Both components accept `group` as a value for the `type` prop, and they also accept a `groupID`. For example, if groupID 99 is the group for schools, then it will show a leaderboard of the top schools.

![image](https://user-images.githubusercontent.com/1445686/37073680-29430e56-2214-11e8-8cb0-a787d82f3ec6.png)
