### PR TITLE
Fetch EDH campaign groups for create page form

### DIFF
--- a/source/components/create-page-form/Readme.md
+++ b/source/components/create-page-form/Readme.md
@@ -8,7 +8,7 @@
 />
 ```
 
-**With extra fields:**
+### With extra fields
 
 ```
 const required = (msg = 'This field is required') => {
@@ -38,6 +38,16 @@ const fields = {
   campaignId='au-0'
   token='1234abcd'
   fields={fields}
+  onSuccess={(result) => alert(JSON.stringify(result))}
+/>
+```
+
+### With groups (EDH only)
+
+```
+<CreatePageForm
+  campaignId='au-21937'
+  token='1234abcd'
   onSuccess={(result) => alert(JSON.stringify(result))}
 />
 ```

--- a/source/components/create-page-form/__tests__/create-page-form-test.js
+++ b/source/components/create-page-form/__tests__/create-page-form-test.js
@@ -6,28 +6,129 @@ import CreatePageForm from '..'
 
 describe ('Components | CreatePageForm', () => {
   describe ('EDH CreatePageForm', () => {
-    it ('renders a simple create page form', () => {
-      const wrapper = mount(<CreatePageForm country='au' clientId='1234abcd' onSuccess={(res) => console.log(res)} />)
-      const inputs = wrapper.find('input')
-      const button = wrapper.find('button')
-
-      expect(inputs.length).to.eql(1)
-      expect(button.length).to.eql(1)
-      expect(button.text()).to.eql('Create Page')
+    beforeEach (() => {
+      moxios.install(instance)
     })
 
-    it ('allows a custom submit button label to be passed', () => {
-      const wrapper = mount(<CreatePageForm clientId='1234abcd' submit='Create Page on EDH' onSuccess={(res) => console.log(res)} />)
-      const button = wrapper.find('button')
-
-      expect(button.length).to.eql(1)
-      expect(button.text()).to.eql('Create Page on EDH')
+    afterEach (() => {
+      moxios.uninstall(instance)
     })
 
-    it ('allows for custom fields to be passed', () => {
-      const wrapper = mount(<CreatePageForm clientId='1234abcd' fields={{ name: { type: 'text'} }} onSuccess={(res) => console.log(res)} />)
-      const inputs = wrapper.find('input')
-      expect(inputs.length).to.eql(2)
+    it ('renders a simple create page form', (done) => {
+      const wrapper = mount(<CreatePageForm campaignId='au-123' token='1234abcd' onSuccess={(res) => console.log(res)} />)
+
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent()
+        expect(request.url).to.contain('https://everydayhero.com/api/v2/campaigns')
+        expect(request.url).to.contain('au-123')
+
+        request.respondWith({
+          status: 200,
+          response: { campaign_groups: [] }
+        })
+
+        // Re-render
+        setTimeout(() => {
+          const inputs = wrapper.find('input')
+          const button = wrapper.find('button')
+
+          expect(inputs.length).to.eql(1)
+          expect(button.length).to.eql(1)
+          expect(button.text()).to.eql('Create Page')
+          done()
+        })
+      })
+    })
+
+    it ('shows a loading spinner while fetching groups', () => {
+      const wrapper = mount(<CreatePageForm campaignId='au-123' token='1234abcd' onSuccess={(res) => console.log(res)} />)
+
+      const icon = wrapper.find('svg')
+      expect(icon.length).to.eql(1)
+    })
+
+    it ('allows a custom submit button label to be passed', (done) => {
+      const wrapper = mount(<CreatePageForm campaignId='au-123' token='1234abcd' submit='Create Page on EDH' onSuccess={(res) => console.log(res)} />)
+
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent()
+        expect(request.url).to.contain('https://everydayhero.com/api/v2/campaigns')
+        expect(request.url).to.contain('au-123')
+
+        request.respondWith({
+          status: 200,
+          response: { campaign_groups: [] }
+        })
+
+        // Re-render
+        setTimeout(() => {
+          const button = wrapper.find('button')
+
+          expect(button.length).to.eql(1)
+          expect(button.text()).to.eql('Create Page on EDH')
+          done()
+        })
+      })
+    })
+
+    it ('allows for custom fields to be passed', (done) => {
+      const wrapper = mount(<CreatePageForm campaignId='au-123' token='1234abcd' fields={{ name: { type: 'text'} }} onSuccess={(res) => console.log(res)} />)
+
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent()
+        expect(request.url).to.contain('https://everydayhero.com/api/v2/campaigns')
+        expect(request.url).to.contain('au-123')
+
+        request.respondWith({
+          status: 200,
+          response: { campaign_groups: [] }
+        })
+
+        // Re-render
+        setTimeout(() => {
+          const inputs = wrapper.find('input')
+
+          expect(inputs.length).to.eql(2)
+          done()
+        })
+      })
+    })
+
+    it ('adds required group fields when fetched', (done) => {
+      const wrapper = mount(<CreatePageForm campaignId='au-456' token='1234abcd' onSuccess={(res) => console.log(res)} />)
+
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent()
+        expect(request.url).to.contain('https://everydayhero.com/api/v2/campaigns')
+        expect(request.url).to.contain('au-456')
+
+        request.respondWith({
+          status: 200,
+          response: {
+            campaign_groups: [
+              {
+                id: 1,
+                key: 'location',
+                label: 'Selection your location',
+                values: ['Brisbane', 'Sydney', 'Melbourne', 'Adelaide', 'Hobart', 'Perth', 'Canberra', 'Darwin']
+              },
+              {
+                id: 2,
+                key: 'source',
+                label: 'How did you hear about us?',
+                values: ['Online', 'TV', 'Radio', 'Word of mouth', 'Other']
+              }
+            ]
+          }
+        }).then(() => {
+          const input = wrapper.find('input')
+          const selects = wrapper.find('select')
+
+          expect(input.length).to.eql(1)
+          expect(selects.length).to.eql(2)
+          done()
+        })
+      })
     })
   })
 
@@ -43,7 +144,7 @@ describe ('Components | CreatePageForm', () => {
     })
 
     it ('renders a simple create page form with custom submit prop', () => {
-      const wrapper = mount(<CreatePageForm onSuccess={(res) => console.log(res)} />)
+      const wrapper = mount(<CreatePageForm eventId='12345' charityId='56789' onSuccess={(res) => console.log(res)} />)
       const inputs = wrapper.find('input')
       const button = wrapper.find('button')
 
@@ -53,7 +154,7 @@ describe ('Components | CreatePageForm', () => {
     })
 
     it ('allows a custom submit button label to be passed', () => {
-      const wrapper = mount(<CreatePageForm submit='Create Page on JustGiving' onSuccess={(res) => console.log(res)} />)
+      const wrapper = mount(<CreatePageForm eventId='12345' charityId='56789' submit='Create Page on JustGiving' onSuccess={(res) => console.log(res)} />)
       const button = wrapper.find('button')
 
       expect(button.length).to.eql(1)
@@ -61,7 +162,7 @@ describe ('Components | CreatePageForm', () => {
     })
 
     it ('allows for custom fields to be passed', () => {
-      const wrapper = mount(<CreatePageForm fields={{ name: { type: 'text'} }} onSuccess={(res) => console.log(res)} />)
+      const wrapper = mount(<CreatePageForm eventId='12345' charityId='56789' fields={{ name: { type: 'text'} }} onSuccess={(res) => console.log(res)} />)
       const inputs = wrapper.find('input')
       expect(inputs.length).to.eql(3)
     })

--- a/source/components/create-page-form/index.js
+++ b/source/components/create-page-form/index.js
@@ -4,14 +4,17 @@ import capitalize from 'lodash/capitalize'
 import get from 'lodash/get'
 import merge from 'lodash/merge'
 import values from 'lodash/values'
+import compose from 'constructicon/lib/compose'
 import withForm from 'constructicon/with-form'
 import * as validators from 'constructicon/lib/validators'
 import { createPage } from '../../api/pages'
 import { isJustGiving } from '../../utils/client'
+import withGroups from './with-groups'
 
 import Form from 'constructicon/form'
 import InputDate from 'constructicon/input-date'
 import InputField from 'constructicon/input-field'
+import InputSelect from 'constructicon/input-select'
 
 class CreatePageForm extends Component {
   constructor () {
@@ -83,6 +86,17 @@ class CreatePageForm extends Component {
     })
   }
 
+  renderInput (type) {
+    switch (type) {
+      case 'date':
+        return InputDate
+      case 'select':
+        return InputSelect
+      default:
+        return InputField
+    }
+  }
+
   render () {
     const {
       disableInvalidForm,
@@ -109,7 +123,7 @@ class CreatePageForm extends Component {
         {...formComponent}>
 
         {values(form.fields).map((field) => {
-          const Tag = field.type === 'date' ? InputDate : InputField
+          const Tag = this.renderInput(field.type)
           return <Tag key={field.name} {...field} {...inputField} />
         })}
       </Form>
@@ -219,4 +233,7 @@ const form = (props) => ({
   }, props.fields)
 })
 
-export default withForm(form)(CreatePageForm)
+export default compose(
+  withGroups,
+  withForm(form)
+)(CreatePageForm)

--- a/source/components/create-page-form/with-groups/index.js
+++ b/source/components/create-page-form/with-groups/index.js
@@ -1,0 +1,81 @@
+import React, { Component } from 'react'
+import merge from 'lodash/merge'
+import startCase from 'lodash/startCase'
+import * as validators from 'constructicon/lib/validators'
+import { fetchCampaignGroups } from '../../../api/campaigns'
+import { isJustGiving } from '../../../utils/client'
+
+import Icon from 'constructicon/icon'
+
+const withGroups = (ComponentToWrap) => (
+  class extends Component {
+    constructor (props) {
+      super(props)
+      this.fetchGroups = this.fetchGroups.bind(this)
+
+      this.state = {
+        fields: null,
+        isFetched: isJustGiving()
+      }
+    }
+
+    componentDidMount () {
+      if (!isJustGiving()) this.fetchGroups()
+    }
+
+    fetchGroups () {
+      const { campaignId } = this.props
+
+      fetchCampaignGroups(campaignId).then((groups) => {
+        const fields = {}
+
+        if (groups.length) {
+          groups.forEach(({ key, label, values }) => {
+            const name = startCase(key)
+            const options = [
+              {
+                label: `Select a ${name}`,
+                value: '',
+                disabled: true
+              },
+              ...values.map((value) => ({
+                label: value,
+                value
+              }))
+            ]
+
+            fields[key] = {
+              label,
+              options,
+              type: 'select',
+              required: true,
+              validators: [
+                validators.required(`Please select a ${name}`)
+              ]
+            }
+          })
+        }
+
+        return this.setState({
+          fields,
+          isFetched: true
+        })
+      })
+    }
+
+    render () {
+      const { isFetched } = this.state
+
+      return isFetched ? (
+        <ComponentToWrap
+          {...this.props}
+          fields={merge(this.props.fields, this.state.fields)}
+        />
+      ) : (
+        <Icon name='loading' spin />
+      )
+    }
+  }
+)
+
+export default withGroups


### PR DESCRIPTION
If the environment is EDH we automatically fetch the groups for the specified campaign before rendering the `CreatePageForm` (_for JG this is skipped_).

If any groups are found, the group values are added as required fields to the form.