### PR TITLE
Third-party OAuth Button

### DIFF
--- a/source/components/provider-oauth-button/Readme.md
+++ b/source/components/provider-oauth-button/Readme.md
@@ -1,0 +1,34 @@
+# Examples
+
+N.B. Support for the default popup functionality is IE11+
+
+```
+<ProviderOauthButton
+  clientId='26de0618f8469b55bee0e134c56e938da64566234dd935855daec36c294a5a65'
+  redirectUri='https://oauth.blackbaud-sites.com'
+  onClose={() => console.log('Popup closed!')}
+  onSuccess={(result) => alert(JSON.stringify(result))}
+/>
+```
+
+You can disable the default popup functionality by setting `popup` to false.
+
+```
+<ProviderOauthButton
+  clientId='26de0618f8469b55bee0e134c56e938da64566234dd935855daec36c294a5a65'
+  redirectUri='https://oauth.blackbaud-sites.com'
+  popup={false}
+  provider='strava'
+  label='Connect with Strava'
+/>
+```
+
+```
+<ProviderOauthButton
+  clientId='26de0618f8469b55bee0e134c56e938da64566234dd935855daec36c294a5a65'
+  redirectUri='https://oauth.blackbaud-sites.com'
+  popup={false}
+  provider='mapmyfitness'
+  label='Connect with Map My Fitness'
+/>
+```

--- a/source/components/provider-oauth-button/__tests__/provider-oauth-button-test.js
+++ b/source/components/provider-oauth-button/__tests__/provider-oauth-button-test.js
@@ -1,0 +1,73 @@
+import React from 'react'
+import moxios from 'moxios'
+import { instance, updateClient } from '../../../utils/client'
+
+import ProviderOauthButton from '..'
+
+describe ('Components | ProviderOauthButton', () => {
+  describe ('EDH ProviderOauthButton', () => {
+    it ('renders a default button', () => {
+      const wrapper = mount(
+        <ProviderOauthButton
+          clientId='1234'
+          redirectUri='https://everydayhero.com'
+        />
+      )
+
+      const button = wrapper.find('button')
+      expect(button.length).to.eql(1)
+      expect(button.text()).to.eql('Login with Facebook')
+    })
+
+    it ('renders a link with no popup', () => {
+      const wrapper = mount(
+        <ProviderOauthButton
+          clientId='1234'
+          redirectUri='https://google.com'
+          popup={false}
+        />
+      )
+
+      const link = wrapper.find('a')
+      expect(link.length).to.eql(1)
+      expect(link.prop('href')).to.include('https://everydayhero.com/oauth/authorize')
+      expect(link.prop('href')).to.include('google.com')
+    })
+
+    it ('sets a different provider when passed', () => {
+      const wrapper = mount(
+        <ProviderOauthButton
+          clientId='1234'
+          redirectUri='https://google.com'
+          provider='strava'
+          label='Connect with Strava'
+          popup={false}
+        />
+      )
+
+      const link = wrapper.find('a')
+      expect(link.length).to.eql(1)
+      expect(link.prop('href')).to.include('force_provider=strava')
+      expect(link.prop('href')).to.include('google.com')
+      expect(link.text()).to.eql('Connect with Strava')
+    })
+  })
+
+  describe ('JG ProviderOauthButton', () => {
+    beforeEach (() => {
+      updateClient({ baseURL: 'https://api.justgiving.com', headers: { 'x-api-key': 'abcd1234' } })
+      moxios.install(instance)
+    })
+
+    afterEach (() => {
+      updateClient({ baseURL: 'https://everydayhero.com' })
+      moxios.uninstall(instance)
+    })
+
+    it ('does not render a button', () => {
+      const wrapper = mount(<ProviderOauthButton clientId='1234' redirectUri='https://justgiving.com' />)
+      const a = wrapper.find('a')
+      expect(a.length).to.eql(0)
+    })
+  })
+})

--- a/source/components/provider-oauth-button/index.js
+++ b/source/components/provider-oauth-button/index.js
@@ -1,0 +1,170 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import omit from 'lodash/omit'
+import snakeCase from 'lodash/snakeCase'
+import { getBaseURL, isJustGiving } from '../../utils/client'
+
+import Button from 'constructicon/button'
+import Icon from 'constructicon/icon'
+
+class ProviderOauthButton extends Component {
+  constructor (props) {
+    super(props)
+    this.handleAuth = this.handleAuth.bind(this)
+    this.providerUrl = this.providerUrl.bind(this)
+
+    this.state = {
+      loading: false
+    }
+  }
+
+  isValidUri (url) {
+    try {
+      return new window.URL(url)
+    } catch (error) {
+      return false
+    }
+  }
+
+  componentDidMount () {
+    const { onSuccess, redirectUri } = this.props
+
+    if (this.isValidUri(redirectUri) && typeof onSuccess === 'function') {
+      const { addEventListener, URL } = window
+      const validSourceOrigin = new URL(redirectUri).origin
+
+      addEventListener('message', (event) => {
+        if (event.origin !== validSourceOrigin) { return }
+        this.setState({ loading: false })
+        return onSuccess(event.data)
+      }, false)
+    }
+  }
+
+  handleAuth () {
+    const {
+      popupWindowFeatures,
+      provider,
+      onClose
+    } = this.props
+
+    const newWindow = window.open(this.providerUrl(), `${provider}-auth`, popupWindowFeatures)
+
+    this.setState({ loading: true })
+
+    const isPopupClosed = setInterval(() => {
+      if (newWindow.closed) {
+        clearInterval(isPopupClosed)
+        this.setState({ loading: false })
+
+        if (typeof onClose === 'function') {
+          return onClose(newWindow)
+        }
+      }
+    }, 1000)
+  }
+
+  providerUrl () {
+    const {
+      clientId,
+      provider,
+      redirectUri
+    } = this.props
+
+    const params = {
+      clientId,
+      forceProvider: provider,
+      redirectUri,
+      responseType: 'token'
+    }
+
+    const urlParams = Object.keys(params).map((key) => (
+      `${snakeCase(key)}=${encodeURIComponent(params[key])}`
+    )).join('&')
+
+    return `${getBaseURL()}/oauth/authorize?${urlParams}`
+  }
+
+  render () {
+    const {
+      label,
+      popup,
+      provider,
+      ...props
+    } = this.props
+
+    const { loading } = this.state
+
+    if (isJustGiving()) { return null }
+
+    const actionProps = popup ? {
+      onClick: (e) => this.handleAuth()
+    } : {
+      href: this.providerUrl(),
+      tag: 'a'
+    }
+
+    return (
+      <Button
+        aria-label={label}
+        background={provider}
+        disabled={loading}
+        {...actionProps}
+        {...omit(props, ['clientId', 'onClose', 'onSuccess', 'popupWindowFeatures', 'redirectUri'])}>
+        <Icon name={loading ? 'loading' : provider} spin={loading} size={1.5} />
+        <span>{label}</span>
+      </Button>
+    )
+  }
+}
+
+ProviderOauthButton.propTypes = {
+  /**
+  * The EDH OAuthApplication client ID
+  */
+  clientId: PropTypes.string.isRequired,
+
+  /**
+  * Button label
+  */
+  label: PropTypes.any,
+
+  /**
+  * The onClose event handler if popup is closed
+  */
+  onClose: PropTypes.func,
+
+  /**
+  * The onSuccess event handler if using a popup
+  */
+  onSuccess: PropTypes.func,
+
+  /**
+  * Whether to handle with a popup
+  */
+  popup: PropTypes.bool,
+
+  /**
+  * The features for the popup window (see https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features)
+  */
+  popupWindowFeatures: PropTypes.string,
+
+  /**
+  * The third-party provider to connect with
+  */
+  provider: PropTypes.oneOf(['facebook', 'mapmyfitness', 'strava']),
+
+  /**
+  * A valid return_to url for the specified EDH OAuthApplication
+  */
+  redirectUri: PropTypes.string.isRequired
+}
+
+ProviderOauthButton.defaultProps = {
+  label: 'Login with Facebook',
+  popup: true,
+  popupWindowFeatures: 'width=800,height=600,status=1',
+  provider: 'facebook'
+}
+
+export default ProviderOauthButton

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -37,6 +37,7 @@ module.exports = {
       components: () => ([
         path.resolve(__dirname, 'source/components/create-page-form', 'index.js'),
         path.resolve(__dirname, 'source/components/login-form', 'index.js'),
+        path.resolve(__dirname, 'source/components/provider-oauth-button', 'index.js'),
         path.resolve(__dirname, 'source/components/reset-password-form', 'index.js'),
         path.resolve(__dirname, 'source/components/signup-form', 'index.js'),
         path.resolve(__dirname, 'source/components/single-sign-on-link', 'index.js')


### PR DESCRIPTION
The default functionality is to open a popup window with an EDH OAuth URL. On successful login/signup the user is redirected back to the specified `redirectUri` within the popup. An `onSuccess` function is only fired if the component receives a `postMessage` from the origin specified in the `redirectUri` prop.

I have setup an [example site](view-source:https://oauth.blackbaud-sites.com/) to be used as a redirect URI in any EDH OAuth app. It handles parsing the location hash and sending a message to any domain. It also closes itself if it's in a popup.

Alternatively by setting `popup={false}`, a link with the OAuth url will be rendered and you will have to handle the callback in the specified `redirectUri`. 

**_N.B. JG is not supported :(_**

![Preview](https://user-images.githubusercontent.com/729085/37188444-e6589c40-239a-11e8-8769-fb306551bd79.gif)
