### PR TITLE
Properly set fields for CreatePageForm with EDH groups

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "2.4.6",
+  "version": "2.4.7",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/components/create-page-form/index.js
+++ b/source/components/create-page-form/index.js
@@ -2,7 +2,9 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import capitalize from 'lodash/capitalize'
 import get from 'lodash/get'
+import mapKeys from 'lodash/mapKeys'
 import merge from 'lodash/merge'
+import pickBy from 'lodash/pickBy'
 import values from 'lodash/values'
 import compose from 'constructicon/lib/compose'
 import withForm from 'constructicon/with-form'
@@ -46,13 +48,16 @@ class CreatePageForm extends Component {
         status: 'fetching'
       })
 
+      const groupFields = pickBy(data, (value, key) => /^group_values_/.test(key))
+
       const dataPayload = merge({
         campaignId,
         charityFunded,
         charityId,
         charityOptIn: true,
         eventId,
-        token
+        token,
+        groupValues: mapKeys(groupFields, (value, key) => key.replace('group_values_', ''))
       }, data)
 
       return createPage(dataPayload).then((result) => {
@@ -66,7 +71,7 @@ class CreatePageForm extends Component {
 
             return this.setState({
               status: 'failed',
-              errors: errors.map(({ field, message }) => ({ message: [capitalize(field), message].join(' ') }))
+              errors: errors.map(({ field, message }) => ({ message: [capitalize(field.split('_').join(' ')), message].join(' ') }))
             })
           case 400:
             const errorMessages = error.data || []

--- a/source/components/create-page-form/with-groups/index.js
+++ b/source/components/create-page-form/with-groups/index.js
@@ -44,7 +44,7 @@ const withGroups = (ComponentToWrap) => (
               }))
             ]
 
-            fields[key] = {
+            fields[`group_values_${key}`] = {
               label,
               options,
               type: 'select',


### PR DESCRIPTION
Previously the added group values were being passed as fields with their group name, but the [`createPage` API method](https://github.com/everydayhero/supporticon/tree/master/source/api/pages#createpage) requires a value for `groupValues` to be set to correctly map the values for the API call to supporter