### PR TITLE
Resolve numbro currency formatting issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "2.4.9",
+  "version": "2.4.10",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "axios": "^0.15.3",
-    "numbro": "^1.9.3",
+    "numbro": "^1.11.0",
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {

--- a/source/components/leaderboard/index.js
+++ b/source/components/leaderboard/index.js
@@ -164,7 +164,7 @@ class Leaderboard extends Component {
         title={leader.name}
         subtitle={leader.subtitle}
         image={leader.image}
-        amount={numbro(leader.raised).formatCurrency('$0,0')}
+        amount={numbro(leader.raised).formatCurrency('0,0')}
         href={leader.url}
         rank={leader.position}
         {...leaderboardItem}

--- a/source/components/total-funds-raised/index.js
+++ b/source/components/total-funds-raised/index.js
@@ -166,7 +166,7 @@ TotalFundsRaised.defaultProps = {
   label: 'Funds Raised',
   offset: 0,
   multiplier: 1,
-  format: '$0,0'
+  format: '0,0'
 }
 
 export default TotalFundsRaised

--- a/yarn.lock
+++ b/yarn.lock
@@ -5902,9 +5902,9 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-numbro@^1.9.3:
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/numbro/-/numbro-1.9.3.tgz#47f727f580aef49fcd5fdd5fa2af7e603e68b530"
+numbro@^1.11.0:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/numbro/-/numbro-1.11.1.tgz#e0d9ba0ddfc3ad5ac01d9558a49383db214f04be"
 
 "nwmatcher@>= 1.3.9 < 2.0.0":
   version "1.3.9"


### PR DESCRIPTION
From [the docs](http://numbrojs.com/old-format.html#currency):

> You can of course precise a more specific format, as long as you do not use the $ (that would override defaults).