### PR TITLE
Add Teams API methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "2.4.12",
+  "version": "2.5.0",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/teams/__tests__/create-team--test.js
+++ b/source/api/teams/__tests__/create-team--test.js
@@ -1,0 +1,75 @@
+import moxios from 'moxios'
+import { createTeam } from '..'
+import { instance, updateClient } from '../../../utils/client'
+
+describe ('Create a Team', () => {
+  beforeEach (() => {
+    moxios.install(instance)
+  })
+
+  afterEach (() => {
+    moxios.uninstall(instance)
+  })
+
+  describe ('Create EDH Team', () => {
+    it ('throws if no token is passed', () => {
+      const test = () => createTeam({ bogus: 'data' })
+      expect(test).to.throw
+    })
+
+    it ('hits the supporter api with the correct url and data', (done) => {
+      createTeam({
+        token: '012345abcdef',
+        page: 1234,
+        name: 'My Team'
+      })
+
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent()
+        const data = JSON.parse(request.config.data)
+
+        expect(request.url).to.contain('https://everydayhero.com/api/v2/teams')
+        expect(request.config.headers['Authorization']).to.eql('Bearer 012345abcdef')
+        expect(data.name).to.eql('My Team')
+        done()
+      })
+    })
+  })
+
+  describe ('Create JG Team', () => {
+    beforeEach (() => {
+      moxios.install(instance)
+      updateClient({ baseURL: 'https://api.justgiving.com' })
+    })
+
+    afterEach (() => {
+      moxios.uninstall(instance)
+      updateClient({ baseURL: 'https://everydayhero.com' })
+    })
+
+    it ('throws if no token is passed', () => {
+      const test = () => createTeam({ bogus: 'data' })
+      expect(test).to.throw
+    })
+
+    it ('hits the JG api with the correct url and data', (done) => {
+      createTeam({
+        token: '012345abcdef',
+        name: 'My Team',
+        slug: 'my-team',
+        story: 'Lorem ipsum',
+        target: 1000
+      })
+
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent()
+        const data = JSON.parse(request.config.data)
+
+        expect(request.url).to.contain('https://api.justgiving.com/v1/team')
+        expect(request.config.headers['Authorization']).to.eql('Basic 012345abcdef')
+        expect(data.teamShortName).to.eql('my-team')
+        done()
+      })
+    })
+  })
+})

--- a/source/api/teams/__tests__/fetch-team--test.js
+++ b/source/api/teams/__tests__/fetch-team--test.js
@@ -1,0 +1,84 @@
+import moxios from 'moxios'
+import { fetchTeams, fetchTeam } from '..'
+import { instance, updateClient } from '../../../utils/client'
+
+describe ('Fetch Teams', () => {
+  beforeEach (() => {
+    moxios.install(instance)
+  })
+
+  afterEach (() => {
+    moxios.uninstall(instance)
+  })
+
+  describe ('Fetch EDH Teams', () => {
+    describe ('Fetch many teams', () => {
+      it ('uses the correct url to fetch teams', (done) => {
+        fetchTeams({ token: '123456' })
+        moxios.wait(() => {
+          const request = moxios.requests.mostRecent()
+          expect(request.url).to.contain('https://everydayhero.com/api/v2/teams')
+          done()
+        })
+      })
+
+      it ('throws if no params are passed in', () => {
+        const test = () => fetchTeams()
+        expect(test).to.throw
+      })
+    })
+
+    describe ('Fetch a single team', () => {
+      it ('uses the correct url to fetch a single team', (done) => {
+        fetchTeam({ id: '1234', token: '123456' })
+        moxios.wait(() => {
+          const request = moxios.requests.mostRecent()
+          expect(request.url).to.contain('https://everydayhero.com/api/v2/teams')
+          expect(request.url).to.contain('1234')
+          done()
+        })
+      })
+
+      it ('throws if no params are passed in', () => {
+        const test = () => fetchTeam()
+        expect(test).to.throw
+      })
+    })
+  })
+
+  describe ('Fetch JG Teams', () => {
+    beforeEach (() => {
+      moxios.install(instance)
+      updateClient({ baseURL: 'https://api.justgiving.com' })
+    })
+
+    afterEach (() => {
+      moxios.uninstall(instance)
+      updateClient({ baseURL: 'https://everydayhero.com' })
+    })
+
+    describe ('Fetch many teams', () => {
+      it ('throws unsupported error', () => {
+        const test = () => fetchTeams()
+        expect(test).to.throw
+      })
+    })
+
+    describe ('Fetch a single team', () => {
+      it ('uses the correct url to fetch a single team', (done) => {
+        fetchTeam('my-team')
+        moxios.wait(() => {
+          const request = moxios.requests.mostRecent()
+          expect(request.url).to.contain('https://api.justgiving.com/v1/team')
+          expect(request.url).to.contain('my-team')
+          done()
+        })
+      })
+
+      it ('throws if no params are passed in', () => {
+        const test = () => fetchTeam()
+        expect(test).to.throw
+      })
+    })
+  })
+})

--- a/source/api/teams/__tests__/join-team--test.js
+++ b/source/api/teams/__tests__/join-team--test.js
@@ -1,0 +1,72 @@
+import moxios from 'moxios'
+import { joinTeam } from '..'
+import { instance, updateClient } from '../../../utils/client'
+
+describe ('Join a Team', () => {
+  beforeEach (() => {
+    moxios.install(instance)
+  })
+
+  afterEach (() => {
+    moxios.uninstall(instance)
+  })
+
+  describe ('Join EDH Team', () => {
+    it ('throws if no token is passed', () => {
+      const test = () => joinTeam({ bogus: 'data' })
+      expect(test).to.throw
+    })
+
+    it ('hits the supporter api with the correct url and data', (done) => {
+      joinTeam({
+        token: '012345abcdef',
+        id: 4321,
+        page: 1234
+      })
+
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent()
+        const data = JSON.parse(request.config.data)
+
+        expect(request.url).to.contain('https://everydayhero.com/api/v2/teams')
+        expect(request.config.headers['Authorization']).to.eql('Bearer 012345abcdef')
+        done()
+      })
+    })
+  })
+
+  describe ('Join JG Team', () => {
+    beforeEach (() => {
+      moxios.install(instance)
+      updateClient({ baseURL: 'https://api.justgiving.com' })
+    })
+
+    afterEach (() => {
+      moxios.uninstall(instance)
+      updateClient({ baseURL: 'https://everydayhero.com' })
+    })
+
+    it ('throws if no token is passed', () => {
+      const test = () => joinTeam({ bogus: 'data' })
+      expect(test).to.throw
+    })
+
+    it ('hits the JG api with the correct url and data', (done) => {
+      joinTeam({
+        id: 'my-team',
+        page: 'my-page',
+        token: '012345abcdef'
+      })
+
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent()
+        const data = JSON.parse(request.config.data)
+
+        expect(request.url).to.contain('https://api.justgiving.com/v1/team/join')
+        expect(request.config.headers['Authorization']).to.eql('Basic 012345abcdef')
+        expect(data.pageShortName).to.eql('my-page')
+        done()
+      })
+    })
+  })
+})

--- a/source/api/teams/everydayhero/index.js
+++ b/source/api/teams/everydayhero/index.js
@@ -1,0 +1,65 @@
+import { get, post } from '../../../utils/client'
+import { required } from '../../../utils/params'
+
+export const deserializeTeam = (team) => ({
+  id: team.id,
+  leader: team.leader_id,
+  name: team.name,
+  pages: team.page_ids,
+  raised: null,
+  slug: null
+})
+
+export const fetchTeams = ({
+  token = required()
+}) => {
+  return get('api/v2/teams', {}, {}, {
+    headers: {
+      'Authorization': `Bearer ${token}`
+    }
+  })
+  .then((response) => response.teams)
+}
+
+export const fetchTeam = ({
+  id = required(),
+  token = required()
+}) => {
+  return get(`api/v2/teams/${id}`, {}, {}, {
+    headers: {
+      'Authorization': `Bearer ${token}`
+    }
+  })
+  .then((response) => response.team)
+}
+
+export const createTeam = ({
+  token = required(),
+  page = required(),
+  name
+}) => {
+  return post('api/v2/teams', {
+    individual_page_id: page,
+    name
+  }, {
+    headers: {
+      'Authorization': `Bearer ${token}`
+    }
+  })
+  .then((response) => response.page)
+}
+
+export const joinTeam = ({
+  id = required(),
+  page = required(),
+  token = required()
+}) => {
+  return post(`api/v2/teams/${id}/join-requests`, {
+    individual_page_id: page
+  }, {
+    headers: {
+      'Authorization': `Bearer ${token}`
+    }
+  })
+  .then((response) => response.team)
+}

--- a/source/api/teams/index.js
+++ b/source/api/teams/index.js
@@ -1,0 +1,47 @@
+import { isJustGiving } from '../../utils/client'
+
+import {
+  deserializeTeam as deserializeJGTeam,
+  fetchTeams as fetchJGTeams,
+  fetchTeam as fetchJGTeam,
+  createTeam as createJGTeam,
+  joinTeam as joinJGTeam
+} from './justgiving'
+
+import {
+  deserializeTeam as deserializeEDHTeam,
+  fetchTeams as fetchEDHTeams,
+  fetchTeam as fetchEDHTeam,
+  createTeam as createEDHTeam,
+  joinTeam as joinEDHTeam
+} from './everydayhero'
+
+export const deserializeTeam = (team) => (
+  isJustGiving()
+    ? deserializeJGTeam(team)
+    : deserializeEDHTeam(team)
+)
+
+export const fetchTeams = (params) => {
+  return isJustGiving()
+    ? fetchJGTeams(params)
+    : fetchEDHTeams(params)
+}
+
+export const fetchTeam = (params) => (
+  isJustGiving()
+    ? fetchJGTeam(params)
+    : fetchEDHTeam(params)
+)
+
+export const createTeam = (params) => (
+  isJustGiving()
+    ? createJGTeam(params)
+    : createEDHTeam(params)
+)
+
+export const joinTeam = (params) => (
+  isJustGiving()
+    ? joinJGTeam(params)
+    : joinEDHTeam(params)
+)

--- a/source/api/teams/justgiving/index.js
+++ b/source/api/teams/justgiving/index.js
@@ -1,0 +1,56 @@
+import { get, put } from '../../../utils/client'
+import { required } from '../../../utils/params'
+
+export const deserializeTeam = (team) => ({
+  id: team.id,
+  leader: null,
+  name: team.name,
+  pages: team.teamMembers,
+  raised: team.raisedSoFar,
+  slug: team.teamShortName
+})
+
+export const fetchTeams = () => {
+  return Promise.reject(new Error('This method is not supported for JustGiving'))
+}
+
+export const fetchTeam = (id = required()) => {
+  return get(`v1/team/${id}`)
+}
+
+export const createTeam = ({
+  name = required(),
+  slug = required(),
+  story = required(),
+  target = required(),
+  targetType = 'Fixed',
+  teamType = 'Open',
+  token = required()
+}) => {
+  return put('v1/team', {
+    name,
+    story,
+    targetType,
+    teamShortName: slug,
+    teamTarget: target,
+    teamType
+  }, {
+    headers: {
+      'Authorization': `Basic ${token}`
+    }
+  })
+}
+
+export const joinTeam = ({
+  id = required(),
+  page = required(),
+  token = required()
+}) => {
+  return put(`v1/team/join/${id}`, {
+    pageShortName: page
+  }, {
+    headers: {
+      'Authorization': `Basic ${token}`
+    }
+  })
+}

--- a/source/api/teams/readme.md
+++ b/source/api/teams/readme.md
@@ -1,0 +1,153 @@
+# Goal
+
+Helpers related to fetching teams
+
+- [deserializeTeam](#deserializeteam)
+- [fetchTeams](#fetchteams)
+- [fetchTeam](#fetchteam)
+- [createTeam](#createteam)
+- [joinTeam](#updateteam)
+
+
+## `deserializeTeam`
+
+A default deserializer for deserializing teams
+
+**Params**
+
+- `data` {Object} a single team to deserialize
+
+**Returns**
+
+The deserialized team
+
+**Example**
+
+```javascript
+import { deserializeTeam } from 'supporticon/api/teams'
+
+// ...
+
+return {
+  status: 'fetched',
+  data: payload.data.map(deserializeTeam)
+}
+```
+
+
+## `fetchTeams`
+
+**Purpose**
+
+Fetch teams for an authenticated user.
+
+**Params**
+
+- `token` (String) OAuth User Token _required_
+
+**Returns**
+
+A pending promise that will either resolve to:
+
+- Success: the data returned from the request
+- Failure: the error encountered
+
+**Example**
+
+```javascript
+import { fetchTeams } from 'supporticon/api/teams'
+
+fetchTeams({
+  token: 'abcd-123456'
+})
+```
+
+
+## `fetchTeam`
+
+**Purpose**
+
+Fetch a team for an authenticated user.
+
+**Params**
+
+- `id` (Integer) Team ID _required_
+- `token` (String) OAuth User Token _required_
+
+**Returns**
+
+A pending promise that will either resolve to:
+
+- Success: the data returned from the request
+- Failure: the error encountered
+
+**Example**
+
+```javascript
+import { fetchTeam } from 'supporticon/api/teams'
+
+fetchTeam({
+  id: 1234,
+  token: 'abcd-123456'
+})
+```
+
+
+## `createTeam`
+
+Create a team for an authenticated user.
+
+**Params**
+
+- `token` (String) OAuth User Token _required_
+- `page` (Integer) Page ID _required_
+- `name` (String) Team Name
+
+**Returns**
+
+A pending promise that will either resolve to:
+
+- Success: the data returned from the request
+- Failure: the error encountered
+
+**Example**
+
+```javascript
+import { createTeam } from 'supporticon/api/teams'
+
+createTeam({
+  token: 'xxxxx',
+  page: 1234,
+  name: 'My Team'
+})
+```
+
+
+## `joinTeam`
+
+Create a team for an authenticated user.
+
+**Params**
+
+- `token` (String) OAuth User Token _required_
+- `page` (Integer) Page ID _required_
+- `id` (Integer) Team ID _required_
+
+**Returns**
+
+A pending promise that will either resolve to:
+
+- Success: the data returned from the request
+- Failure: the error encountered
+
+**Example**
+
+```javascript
+import { joinTeam } from 'supporticon/api/teams'
+
+joinTeam({
+  token: 'xxxxx',
+  page: 1234,
+  id: 4321
+})
+```


### PR DESCRIPTION
Helpers related to fetching teams

- `deserializeTeam`
- [`fetchTeams`](http://developer.everydayhero.com/teams/)
- [`fetchTeam`](http://developer.everydayhero.com/teams/)
- [`createTeam`](http://developer.everydayhero.com/teams/)
- [`joinTeam`](http://developer.everydayhero.com/join-requests/)

Also supports JG where applicable, though I believe the Team APIs will be deprecated at some point: http://api.justgiving.com/docs/resources/v1/Team