### PR TITLE
Add `searchPages` API method **v3.0.0**

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "2.5.0",
+  "version": "3.0.0",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/pages/__tests__/fetch-test.js
+++ b/source/api/pages/__tests__/fetch-test.js
@@ -17,7 +17,7 @@ describe ('Fetch Pages', () => {
         fetchPages({ campaign_id: 'au-6839' })
         moxios.wait(() => {
           const request = moxios.requests.mostRecent()
-          expect(request.url).to.contain('https://everydayhero.com/api/v2/search/pages')
+          expect(request.url).to.contain('https://everydayhero.com/api/v2/pages')
           expect(request.url).to.contain('campaign_id=au-6839')
           done()
         })
@@ -50,29 +50,20 @@ describe ('Fetch Pages', () => {
   describe ('Fetch JG Pages', () => {
     beforeEach (() => {
       updateClient({ baseURL: 'https://api.justgiving.com' })
+      moxios.install(instance)
     })
 
     afterEach (() => {
       updateClient({ baseURL: 'https://everydayhero.com' })
+      moxios.uninstall(instance)
     })
 
     describe ('Fetch many pages', () => {
       it ('uses the correct url to fetch pages', (done) => {
-        fetchPages({ campaign: 'CAMPAIGN_ID' })
+        fetchPages({ token: '123456' })
         moxios.wait(() => {
           const request = moxios.requests.mostRecent()
-          expect(request.url).to.contain('https://api.justgiving.com/v1/onesearch')
-          expect(request.url).to.contain('campaignId=CAMPAIGN_ID')
-          done()
-        })
-      })
-
-      it ('uses the uid name as the param when an object is supplied', (done) => {
-        fetchPages({ campaign: { uid: 'UID', shortName: 'SHORT_NAME' } })
-        moxios.wait(() => {
-          const request = moxios.requests.mostRecent()
-          expect(request.url).to.contain('https://api.justgiving.com/v1/onesearch')
-          expect(request.url).to.contain('campaignId=UID')
+          expect(request.url).to.contain('https://api.justgiving.com/v1/fundraising/pages')
           done()
         })
       })

--- a/source/api/pages/__tests__/search-test.js
+++ b/source/api/pages/__tests__/search-test.js
@@ -1,0 +1,67 @@
+import moxios from 'moxios'
+import { searchPages } from '..'
+import { instance, updateClient } from '../../../utils/client'
+
+describe ('Search Pages', () => {
+  beforeEach (() => {
+    moxios.install(instance)
+  })
+
+  afterEach (() => {
+    moxios.uninstall(instance)
+  })
+
+  describe ('Search EDH Pages', () => {
+    it ('uses the correct url to fetch pages', (done) => {
+      searchPages({ campaign_id: 'au-6839' })
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent()
+        expect(request.url).to.contain('https://everydayhero.com/api/v2/search/pages')
+        expect(request.url).to.contain('campaign_id=au-6839')
+        done()
+      })
+    })
+
+    it ('throws if no params are passed in', () => {
+      const test = () => searchPages()
+      expect(test).to.throw
+    })
+  })
+
+  describe ('Search JG Pages', () => {
+    beforeEach (() => {
+      updateClient({ baseURL: 'https://api.justgiving.com' })
+      moxios.install(instance)
+    })
+
+    afterEach (() => {
+      updateClient({ baseURL: 'https://everydayhero.com' })
+      moxios.uninstall(instance)
+    })
+
+    it ('uses the correct url to fetch pages', (done) => {
+      searchPages({ campaign: 'CAMPAIGN_ID' })
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent()
+        expect(request.url).to.contain('https://api.justgiving.com/v1/onesearch')
+        expect(request.url).to.contain('campaignId=CAMPAIGN_ID')
+        done()
+      })
+    })
+
+    it ('uses the uid name as the param when an object is supplied', (done) => {
+      searchPages({ campaign: { uid: 'UID', shortName: 'SHORT_NAME' } })
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent()
+        expect(request.url).to.contain('https://api.justgiving.com/v1/onesearch')
+        expect(request.url).to.contain('campaignId=UID')
+        done()
+      })
+    })
+
+    it ('throws if no params are passed in', () => {
+      const test = () => searchPages()
+      expect(test).to.throw
+    })
+  })
+})

--- a/source/api/pages/everydayhero/index.js
+++ b/source/api/pages/everydayhero/index.js
@@ -22,6 +22,11 @@ export const deserializePage = (page) => ({
 })
 
 export const fetchPages = (params = required()) => {
+  return get('api/v2/pages', params)
+    .then((response) => response.pages)
+}
+
+export const searchPages = (params = required()) => {
   return get('api/v2/search/pages', params)
     .then((response) => response.pages)
 }

--- a/source/api/pages/index.js
+++ b/source/api/pages/index.js
@@ -3,6 +3,7 @@ import { isJustGiving } from '../../utils/client'
 import {
   deserializePage as deserializeEDHPage,
   fetchPages as fetchEDHPages,
+  searchPages as searchEDHPages,
   fetchPage as fetchEDHPage,
   createPage as createEDHPage,
   updatePage as updateEDHPage
@@ -11,50 +12,42 @@ import {
 import {
   deserializePage as deserializeJGPage,
   fetchPages as fetchJGPages,
+  searchPages as searchJGPages,
   fetchPage as fetchJGPage,
   createPage as createJGPage,
   updatePage as updateJGPage
 } from './justgiving'
 
-/**
-* @function deserializer for fundraising pages
-*/
 export const deserializePage = (page) => (
   isJustGiving()
     ? deserializeJGPage(page)
     : deserializeEDHPage(page)
 )
 
-/**
-* @function fetches multiple pages
-*/
 export const fetchPages = (params) => (
   isJustGiving()
     ? fetchJGPages(params)
     : fetchEDHPages(params)
 )
 
-/**
-* @function fetches a single page
-*/
+export const searchPages = (params) => (
+  isJustGiving()
+    ? searchJGPages(params)
+    : searchEDHPages(params)
+)
+
 export const fetchPage = (page) => (
   isJustGiving()
     ? fetchJGPage(page)
     : fetchEDHPage(page)
 )
 
-/**
- * @function create page
- */
 export const createPage = (params) => (
   isJustGiving()
     ? createJGPage(params)
     : createEDHPage(params)
 )
 
-/**
- * @function update page
- */
 export const updatePage = (pageId, params) => (
   isJustGiving()
     ? updateJGPage(pageId, params)

--- a/source/api/pages/justgiving/index.js
+++ b/source/api/pages/justgiving/index.js
@@ -21,7 +21,17 @@ export const deserializePage = (page) => ({
   uuid: null
 })
 
-export const fetchPages = (params = required()) => {
+export const fetchPages = ({
+  token = required()
+}) => {
+  return get('/v1/fundraising/pages', {}, {}, {
+    headers: {
+      'Authorization': `Basic ${token}`
+    }
+  })
+}
+
+export const searchPages = (params = required()) => {
   const {
     campaign,
     charity,


### PR DESCRIPTION
_**This introduces a new MAJOR version with breaking changes**_

The existing `fetchPages` method actually uses a search endpoint, which hides functionality available on `api/v2/pages` && `v1/fundraising/pages` endpoints.

The new `searchPages` method keeps the functionality of the old `fetchPages` method allowing the `fetchPages` method to be more accurate. Note that for JG the method fetches pages for an authenticated user.