### PR TITLE
 Add ability to change endpoint in `fetchPages` method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/pages/__tests__/fetch-test.js
+++ b/source/api/pages/__tests__/fetch-test.js
@@ -23,6 +23,16 @@ describe ('Fetch Pages', () => {
         })
       })
 
+      it ('uses a different endpoint if an `allPages` param is passed', (done) => {
+        fetchPages({ campaign_id: 'au-6839', allPages: true })
+        moxios.wait(() => {
+          const request = moxios.requests.mostRecent()
+          expect(request.url).to.contain('https://everydayhero.com/api/v2/pages')
+          expect(request.url).to.contain('campaign_id=au-6839')
+          done()
+        })
+      })
+
       it ('throws if no params are passed in', () => {
         const test = () => fetchPages()
         expect(test).to.throw

--- a/source/api/pages/everydayhero/index.js
+++ b/source/api/pages/everydayhero/index.js
@@ -2,7 +2,7 @@ import { get, post, put } from '../../../utils/client'
 import { required } from '../../../utils/params'
 
 export const deserializePage = (page) => ({
-  active: page.active,
+  active: page.active || page.state === 'active',
   campaign: page.campaign || page.campaign_name,
   campaignDate: page.campaign_date,
   charity: page.charity || page.charity_name,
@@ -22,7 +22,9 @@ export const deserializePage = (page) => ({
 })
 
 export const fetchPages = (params = required()) => {
-  return get('api/v2/search/pages', params)
+  const url = params.allPages ? 'api/v2/pages' : 'api/v2/search/pages'
+
+  return get(url, params)
     .then((response) => response.pages)
 }
 

--- a/source/api/pages/readme.md
+++ b/source/api/pages/readme.md
@@ -17,6 +17,7 @@ Fetch pages from Supporter.
 **Params**
 
 - `params` (Object) see [parameter list](../readme.md#availableparameters)
+- `allPages` (Boolean) Use `api/v2/pages` endpoint (EDH only)
 
 **Returns**
 


### PR DESCRIPTION
The existing fetchPages method actually uses a search endpoint, which for EDH hides functionality available on the `api/v2/pages` endpoints

You can now add a param `allPages` which uses the index endpoint instead.