### PR TITLE
Use activity prop in fitness leaderboards

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/components/fitness-leaderboard/index.js
+++ b/source/components/fitness-leaderboard/index.js
@@ -34,6 +34,7 @@ class FitnessLeaderboard extends Component {
 
   fetchLeaderboard (q) {
     const {
+      activity,
       campaign,
       charity,
       type,
@@ -54,6 +55,7 @@ class FitnessLeaderboard extends Component {
     })
 
     fetchFitnessLeaderboard({
+      activity,
       campaign,
       charity,
       type,


### PR DESCRIPTION
`activity` is a prop that is defined in the FitnessLeaderboards propTypes, but it actually isn't used! So made a quick change to just grab it and forward it onto the api helper.