### PR TITLE
Remove phone validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "2.7.4",
+  "version": "2.7.5",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/components/signup-form/index.js
+++ b/source/components/signup-form/index.js
@@ -343,8 +343,7 @@ const form = (props) => ({
       type: 'tel',
       required: true,
       validators: [
-        validators.required('Please enter your phone number'),
-        validators.phone('Please enter your 10 digit phone number beginning with a zero')
+        validators.required('Please enter your phone number')
       ]
     }
   }, !isJustGiving() && !props.country ? {


### PR DESCRIPTION
We were strictly expecting a 10 digit phone number, but this doesn't account for so many different types of phone numbers, including those in different regions.

Best solution is just to follow the product's lead, which just means we should validate that it is present.