### PR TITLE
Ability to use localStorage instead of postMessage for popup

### DIFF
--- a/source/components/provider-oauth-button/Readme.md
+++ b/source/components/provider-oauth-button/Readme.md
@@ -32,3 +32,13 @@ You can disable the default popup functionality by setting `popup` to false.
   label='Connect with Map My Fitness'
 />
 ```
+
+```
+<ProviderOauthButton
+  clientId='26de0618f8469b55bee0e134c56e938da64566234dd935855daec36c294a5a65'
+  redirectUri='https://oauth.blackbaud-sites.com'
+  onClose={() => console.log('Popup closed!')}
+  onSuccess={(result) => alert(JSON.stringify(result))}
+  useLocalStorage
+/>
+```


### PR DESCRIPTION
**Problem**

ProviderOauthButton renders a FB (or other provider) button, which opens the Oauth flow in a popup window and listens to the result of the flow using postMessage. The issue was that this does not work reliably in IE11, and relies on certain security settings being enabled on the user's machine.

**Solution**

Add a prop `useLocalStorage`, which keeps the state of the oauth flow in localStorage rather than using postMessage.