### PR TITLE
Simplify group names

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/components/create-page-form/with-groups/index.js
+++ b/source/components/create-page-form/with-groups/index.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react'
 import get from 'lodash/get'
 import merge from 'lodash/merge'
-import startCase from 'lodash/startCase'
 import * as validators from 'constructicon/lib/validators'
 import { fetchCampaignGroups } from '../../../api/campaigns'
 import { isJustGiving } from '../../../utils/client'
@@ -34,10 +33,9 @@ const withGroups = (ComponentToWrap) => (
 
         if (groups.length) {
           groups.forEach(({ key, label, values }) => {
-            const name = startCase(key)
             const options = [
               {
-                label: `Select a ${name}`,
+                label: 'Please select',
                 value: '',
                 disabled: true
               },
@@ -53,7 +51,7 @@ const withGroups = (ComponentToWrap) => (
               type: 'select',
               required: true,
               validators: [
-                validators.required(`Please select a ${name}`)
+                validators.required('Please select an option')
               ]
             }
           })


### PR DESCRIPTION
When building the form using groups, it was trying to build out the default option and the validation option from the name of the key used to create the group.

This works well in many cases, but often the names are not created in a way that build nicely into a sentence, so it is safer to just use generic terminology.