### PR TITLE
Add param to optionally use `search/pages` endpoint in `fetchPagesTotals`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/pages-totals/__tests__/totals-test.js
+++ b/source/api/pages-totals/__tests__/totals-test.js
@@ -4,22 +4,22 @@ import { fetchPagesTotals } from '..'
 import { fetchPagesTotals as fetchEDHPagesTotals } from '../everydayhero'
 import { fetchPagesTotals as fetchJGPagesTotals } from '../justgiving'
 
-describe ('Fetch Pages Totals', () => {
-  it ('throws if no params are passed in', () => {
+describe('Fetch Pages Totals', () => {
+  it('throws if no params are passed in', () => {
     const test = () => fetchPagesTotals()
     expect(test).to.throw
   })
 
-  describe ('Fetch EDH Pages Totals', () => {
-    beforeEach (() => {
+  describe('Fetch EDH Pages Totals', () => {
+    beforeEach(() => {
       moxios.install(instance)
     })
 
-    afterEach (() => {
+    afterEach(() => {
       moxios.uninstall(instance)
     })
 
-    it ('uses the correct url to fetch totals for a campaign', (done) => {
+    it('uses the correct url to fetch totals for a campaign', (done) => {
       fetchEDHPagesTotals({ campaign_id: 'au-6839' })
       moxios.wait(() => {
         const request = moxios.requests.mostRecent()
@@ -29,7 +29,7 @@ describe ('Fetch Pages Totals', () => {
       })
     })
 
-    it ('uses the correct url to fetch totals for a charity', (done) => {
+    it('uses the correct url to fetch totals for a charity', (done) => {
       fetchEDHPagesTotals({ charity_id: 'au-28' })
       moxios.wait(() => {
         const request = moxios.requests.mostRecent()
@@ -38,20 +38,30 @@ describe ('Fetch Pages Totals', () => {
         done()
       })
     })
+
+    it('allows the API url endpoint to be changed via search param', (done) => {
+      fetchEDHPagesTotals({ campaign_id: 'au-6839', search: true })
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent()
+        expect(request.url).to.contain('https://everydayhero.com/api/v2/search/pages')
+        expect(request.url).to.contain('campaign_id=au-6839')
+        done()
+      })
+    })
   })
 
-  describe ('Fetch JG Pages Totals', () => {
-    beforeEach (() => {
+  describe('Fetch JG Pages Totals', () => {
+    beforeEach(() => {
       updateClient({ baseURL: 'https://api.justgiving.com', headers: { 'x-api-key': 'abcd1234' } })
       moxios.install(instance)
     })
 
-    afterEach (() => {
+    afterEach(() => {
       updateClient({ baseURL: 'https://everydayhero.com' })
       moxios.uninstall(instance)
     })
 
-    it ('uses the correct url to fetch totals for an event', (done) => {
+    it('uses the correct url to fetch totals for an event', (done) => {
       fetchJGPagesTotals({ event: 12345 })
       moxios.wait(function () {
         const request = moxios.requests.mostRecent()

--- a/source/api/pages-totals/everydayhero/index.js
+++ b/source/api/pages-totals/everydayhero/index.js
@@ -1,7 +1,7 @@
 import { get } from '../../../utils/client'
 import { required } from '../../../utils/params'
 
-export const fetchPagesTotals = (params = required()) => {
+export const fetchPagesTotals = ({ search, ...params } = required()) => {
   const finalParams = {
     ...params,
     page: 1,
@@ -14,5 +14,20 @@ export const fetchPagesTotals = (params = required()) => {
     endDate: 'end_updated_at'
   }
 
-  return get('api/v2/pages', finalParams, { mappings }).then((results) => results.meta.count)
+  const transforms = {
+    type: type => {
+      switch (type) {
+        case 'individual':
+          return search ? 'user' : 'individual'
+        default:
+          return type
+      }
+    }
+  }
+
+  const url = search ? 'api/v2/search/pages' : 'api/v2/pages'
+
+  return get(url, finalParams, { mappings, transforms }).then(
+    ({ meta }) => (search ? meta.pagination.count : meta.count)
+  )
 }

--- a/source/api/pages-totals/readme.md
+++ b/source/api/pages-totals/readme.md
@@ -14,6 +14,7 @@ Fetch number of pages from Supporter.
 **Params**
 
 - `params` (Object) see [parameter list](../readme.md#availableparameters)
+- `search` (Boolean) Use `api/v2/search/pages` endpoint (EDH only)
 
 **Returns**
 

--- a/source/components/total-supporters/index.js
+++ b/source/components/total-supporters/index.js
@@ -21,7 +21,8 @@ class TotalSupporters extends Component {
       type,
       group,
       startDate,
-      endDate
+      endDate,
+      search
     } = this.props
 
     fetchPagesTotals({
@@ -31,7 +32,8 @@ class TotalSupporters extends Component {
       type,
       group,
       startDate,
-      endDate
+      endDate,
+      search
     })
       .then((data) => {
         this.setState({
@@ -162,7 +164,12 @@ TotalSupporters.propTypes = {
   /**
   * Props to be passed to the Constructicon Metric component
   */
-  metric: PropTypes.object
+  metric: PropTypes.object,
+
+  /**
+  * Use `v2/search/pages` endpoint (EDH only)
+  */
+  search: PropTypes.bool
 }
 
 TotalSupporters.defaultProps = {


### PR DESCRIPTION
| Prop  | Type | Description |
| --------- | ------- | ------ |
| `search` | `bool` | Use v2/search/pages endpoint (EDH only)

For example:

```javascript
import { fetchPagesTotals } from 'supporticon/api/pages-totals'

fetchPagesTotals({
  campaign: 'au-123',
  search: true
})
```