### PR TITLE
Search pages mappings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/pages/everydayhero/index.js
+++ b/source/api/pages/everydayhero/index.js
@@ -26,10 +26,11 @@ export const deserializePage = (page) => ({
 
 export const fetchPages = (params = required()) => {
   const { allPages, ...finalParams } = params
+  const mappings = { type: 'type' }
 
   const promise = allPages
-    ? get('api/v2/pages', finalParams, { mappings: { type: 'type' } })
-    : get('api/v2/search/pages', finalParams)
+    ? get('api/v2/pages', finalParams, { mappings })
+    : get('api/v2/search/pages', finalParams, { mappings })
 
   return promise.then((response) => response.pages)
 }


### PR DESCRIPTION
The search endpoint also uses `type` for team/individual etc, so just ensuring both the normal pages and search pages endpoints use the correct mappings.