### PR TITLE
Fix issues with donation-totals API deserialisation

### DIFF
--- a/source/api/donation-totals/everydayhero/index.js
+++ b/source/api/donation-totals/everydayhero/index.js
@@ -11,11 +11,11 @@ export const fetchDonationTotals = (params = required()) => {
 
 export const deserializeDonationTotals = (totals, excludeOffline) => {
   const offsetOffline = excludeOffline && totals.types.offline_donation
-  const raisedOffset = offsetOffline ? totals.types.offline_donation.total_amount_cents.sum : 0
+  const raisedOffset = offsetOffline ? (totals.types.offline_donation.total_amount_cents.sum || 0) : 0
   const countOffset = offsetOffline ? totals.types.offline_donation.total_amount_cents.count : 0
 
   return {
-    raised: totals.total_amount_cents.sum - raisedOffset / 100 || 0,
-    donations: totals.total_amount_cents.count - countOffset || 0
+    raised: Math.max(0, (totals.total_amount_cents.sum || 0) - raisedOffset) / 100,
+    donations: Math.max(0, totals.total_amount_cents.count - countOffset)
   }
 }


### PR DESCRIPTION
There are a few issues with what I added earlier 🤦

- The API [can return `null`](https://everydayhero-staging.com/api/v2/search/totals?campaign_id=au-6870) instead of an integer for the `sum` value
- Missing parentheses `===` rookie mistake, e.g. `100 - 50 / 100 !== (100 - 50) / 100`
- In the situation where there was **ONLY** offline donations for a campaign, I would have returned a negative value