### PR TITLE
Exclude offline amount in leaderboards

### DIFF
--- a/source/api/leaderboard/everydayhero/index.js
+++ b/source/api/leaderboard/everydayhero/index.js
@@ -47,6 +47,7 @@ const deserializePage = (item, index) => ({
   image: item.image.medium_image_url,
   raised: item.amount.cents / 100,
   target: item.target_cents / 100,
+  offline: (item.offline_amount_cents || 0) / 100,
   currency: item.amount.currency.iso_code,
   currencySymbol: item.amount.currency.symbol,
   groups: item.group_values

--- a/source/api/pages/everydayhero/index.js
+++ b/source/api/pages/everydayhero/index.js
@@ -10,6 +10,7 @@ export const deserializePage = (page) => ({
   donationUrl: page.donation_url,
   expired: page.expired,
   fitness: page.metrics ? page.metrics.fitness : page.fitness_activity_overview,
+  fitnessGoal: page.fitness_goal,
   groups: page.page_groups,
   id: page.id,
   image: page.image.large_image_url,

--- a/source/components/leaderboard/index.js
+++ b/source/components/leaderboard/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import orderBy from 'lodash/orderBy'
 import PropTypes from 'prop-types'
 import numbro from 'numbro'
 import Filter from 'constructicon/filter'
@@ -70,6 +71,22 @@ class Leaderboard extends Component {
     }
   }
 
+  handleData (data, excludeOffline) {
+    const leaderboardData = data.map(deserializeLeaderboard)
+
+    if (excludeOffline) {
+      return orderBy(leaderboardData.map(item => ({
+        ...item,
+        raised: item.raised - item.offline
+      })), ['raised'], ['desc']).map((item, index) => ({
+        ...item,
+        position: index + 1
+      }))
+    }
+
+    return leaderboardData
+  }
+
   fetchLeaderboard (q) {
     const {
       campaign,
@@ -77,6 +94,7 @@ class Leaderboard extends Component {
       country,
       endDate,
       event,
+      excludeOffline,
       excludePageIds,
       group,
       groupID,
@@ -115,7 +133,7 @@ class Leaderboard extends Component {
       .then((data) => {
         this.setState({
           status: 'fetched',
-          data: data.map(deserializeLeaderboard)
+          data: this.handleData(data, excludeOffline)
         })
       })
       .catch((error) => {


### PR DESCRIPTION
This depends on [this PR in supporter](https://github.com/everydayhero/supporter/pull/5549) being deployed to actually work, though there's a fallback to `0` for `offline_amount_cents`, so there's no delay in releasing this.