### PR TITLE
Fix up search page endpoint value transformations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/pages/everydayhero/index.js
+++ b/source/api/pages/everydayhero/index.js
@@ -28,10 +28,13 @@ export const deserializePage = (page) => ({
 export const fetchPages = (params = required()) => {
   const { allPages, ...finalParams } = params
   const mappings = { type: 'type' }
+  const transforms = allPages ? {} : {
+    type: (v) => v === 'individual' ? 'user' : v
+  }
 
   const promise = allPages
-    ? get('api/v2/pages', finalParams, { mappings })
-    : get('api/v2/search/pages', finalParams, { mappings })
+    ? get('api/v2/pages', finalParams, { mappings, transforms })
+    : get('api/v2/search/pages', finalParams, { mappings, transforms })
 
   return promise.then((response) => response.pages)
 }


### PR DESCRIPTION
Search endpoint requires user/team as opposed to individual/team, so we need to ensure the value is transformed correctly.