### PR TITLE
Image quality

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "2.11.3",
+  "version": "2.11.4",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/leaderboard/everydayhero/index.js
+++ b/source/api/leaderboard/everydayhero/index.js
@@ -44,7 +44,7 @@ const deserializePage = (item, index) => ({
   name: item.name,
   subtitle: item.charity_name,
   url: item.url,
-  image: item.image.medium_image_url,
+  image: item.image.large_image_url,
   raised: item.amount.cents / 100,
   target: item.target_cents / 100,
   offline: (item.offline_amount_cents || 0) / 100,


### PR DESCRIPTION
The leaderboard deserializer uses medium_image_url, whereas the page deserializer uses large_image_url. This means images in the supporter tiles are grainy.