### PR TITLE
Fix logic for getting image in JG leaderboard deserializer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "2.11.7",
+  "version": "2.11.8",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/leaderboard/justgiving/index.js
+++ b/source/api/leaderboard/justgiving/index.js
@@ -64,7 +64,7 @@ export const deserializeLeaderboard = (supporter, index) => ({
   name: supporter.pageTitle,
   subtitle: supporter.eventName,
   url: `https://www.justgiving.com/${supporter.pageShortName}`,
-  image: supporter.defaultImage || supporter.pageImages ? `https://images.jg-cdn.com/image/${supporter.pageImages[0]}?template=Size200x200` : null,
+  image: supporter.defaultImage || (supporter.pageImages ? `https://images.jg-cdn.com/image/${supporter.pageImages[0]}?template=Size200x200` : null),
   raised: supporter.raisedAmount,
   target: supporter.targetAmount,
   currency: supporter.currencyCode,


### PR DESCRIPTION
Without the parentheses, it was saying if supporter.defaultImage or supporter.pageImages then do this, otherwise do that i.e. the argument for the ternary was supporter.defaultImage || supporter.pageImages.

With the parentheses, it is saying if there is supporter.defaultImage, use that, otherwise check supporter.pageImages i.e. supporter.defaultImage is used, but if it's falsy, it checks the ternary.