### PR TITLE
JG donation feeds and donation ticker component

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "babel-preset-stage-0": "^6.22.0",
     "babel-register": "^6.22.0",
     "chai": "^3.5.0",
-    "constructicon": "^1.7.4",
+    "constructicon": "^1.7.6",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "gh-pages": "^0.12.0",
@@ -61,7 +61,7 @@
     "url-parse": "^1.4.3"
   },
   "peerDependencies": {
-    "constructicon": "^1.5.6",
+    "constructicon": "^1.7.6",
     "react": "^15.0.0 || ^16.0.0",
     "react-dom": "^15.0.0 || ^16.0.0"
   },

--- a/source/api/feeds/__tests__/index.js
+++ b/source/api/feeds/__tests__/index.js
@@ -2,16 +2,16 @@ import moxios from 'moxios'
 import { fetchDonationFeed } from '..'
 import { instance, updateClient } from '../../../utils/client'
 
-describe ('Fetch EDH Donation Feed', () => {
-  beforeEach (() => {
+describe('Fetch EDH Donation Feed', () => {
+  beforeEach(() => {
     moxios.install(instance)
   })
 
-  afterEach (() => {
+  afterEach(() => {
     moxios.uninstall(instance)
   })
 
-  it ('uses the correct url', (done) => {
+  it('uses the correct url', (done) => {
     fetchDonationFeed({ campaign_id: 'au-6839' })
       .then((response) => console.log(response.data))
     moxios.wait(() => {
@@ -24,19 +24,37 @@ describe ('Fetch EDH Donation Feed', () => {
   })
 })
 
-describe ('Fetch JG Donation Feed', () => {
-  beforeEach (() => {
+describe('Fetch JG Donation Feed', () => {
+  beforeEach(() => {
+    updateClient({ baseURL: 'https://api.justgiving.com', headers: { 'x-api-key': 'abcd1234' } })
     moxios.install(instance)
-    updateClient({ baseURL: 'https://api.justgiving.com' })
   })
 
-  afterEach (() => {
-    moxios.uninstall(instance)
+  afterEach(() => {
     updateClient({ baseURL: 'https://everydayhero.com' })
+    moxios.uninstall(instance)
   })
 
-  it ('throws unsupported error', () => {
-    const test = () => fetchDonationFeed({ campaign: 'au-123' })
-    expect(test).to.throw
+  describe('uses the correct url', () => {
+    it('for a charity', (done) => {
+      fetchDonationFeed({ charity: '12345' })
+
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent()
+        expect(request.url).to.eql('https://api.justgiving.com/v1/charity/12345/donations')
+        done()
+      })
+    })
+
+    it('for a page', (done) => {
+      fetchDonationFeed({ page: { shortName: 'test-page' } })
+
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent()
+        expect(request.url).to.contain('https://api.justgiving.com/v1/fundraising/pages/test-page/donations')
+        expect(request.url).to.contain('pageSize=150')
+        done()
+      })
+    })
   })
 })

--- a/source/api/feeds/everydayhero/index.js
+++ b/source/api/feeds/everydayhero/index.js
@@ -7,6 +7,10 @@ export const fetchDonationFeed = (params) => {
   }
 
   const mappings = {
+    campaign: 'campaign_id',
+    charity: 'charity_id',
+    page: 'page_id',
+    team: 'team_id',
     type: 'type'
   }
 
@@ -15,9 +19,10 @@ export const fetchDonationFeed = (params) => {
 }
 
 export const deserializeDonation = (donation) => ({
-  amount: donation.amount.cents,
+  amount: donation.amount.cents / 100,
   anonymous: donation.anonymous,
   createdAt: donation.created_at,
+  currency: donation.amount.currency.iso_code,
   message: donation.message,
   name: donation.nickname,
   page: donation.page_id,

--- a/source/api/feeds/justgiving/index.js
+++ b/source/api/feeds/justgiving/index.js
@@ -1,7 +1,24 @@
-export const fetchDonationFeed = () => {
-  return Promise.reject(new Error('This method is not supported for JustGiving'))
+import moment from 'moment'
+import { get } from '../../../utils/client'
+import { getShortName, getUID } from '../../../utils/params'
+
+export const fetchDonationFeed = ({ charity, page }) => {
+  if (!charity && !page) {
+    return Promise.reject('You must pass a charity UID or page shortName for this method')
+  }
+
+  const url = charity
+    ? `v1/charity/${getUID(charity)}/donations`
+    : `v1/fundraising/pages/${getShortName(page)}/donations?pageSize=150`
+
+  return get(url).then((response) => response.donations)
 }
 
-export const deserializeDonation = () => {
-  return Promise.reject(new Error('This method is not supported for JustGiving'))
-}
+export const deserializeDonation = (donation) => ({
+  amount: donation.donorLocalAmount || donation.amount,
+  anonymous: !donation.donorDisplayName || donation.donorDisplayName.toLowerCase().trim() === 'anonymous',
+  createdAt: moment.isMoment(moment(donation.donationDate)) && moment(donation.donationDate).toISOString(),
+  currency: donation.donorLocalCurrencyCode || donation.currencyCode,
+  message: donation.message,
+  name: donation.donorDisplayName
+})

--- a/source/components/donation-ticker/Readme.md
+++ b/source/components/donation-ticker/Readme.md
@@ -1,0 +1,25 @@
+### Examples
+
+*Standard Use*
+
+```
+<DonationTicker
+  campaign='au-23374'
+  label='Donations'
+/>
+```
+
+*Custom format*
+
+```
+<DonationTicker
+  charity='au-23374'
+  format='0a'
+  layout='amount-only'
+  ticker={{
+    background: 'secondary',
+    foreground: 'light',
+    speed: 'fast'
+  }}
+/>
+```

--- a/source/components/donation-ticker/index.js
+++ b/source/components/donation-ticker/index.js
@@ -1,0 +1,159 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import numbro from 'numbro'
+import { fetchDonationFeed, deserializeDonation } from '../../api/feeds'
+
+import Loading from 'constructicon/loading'
+import Metric from 'constructicon/metric'
+import Ticker from 'constructicon/ticker'
+
+class DonationTicker extends Component {
+  constructor () {
+    super()
+    this.fetchData = this.fetchData.bind(this)
+    this.formatDonation = this.formatDonation.bind(this)
+    this.state = {
+      donations: [],
+      status: 'fetching'
+    }
+  }
+
+  componentDidMount () {
+    const { refreshInterval } = this.props
+    this.fetchData()
+    this.interval = refreshInterval && setInterval(this.fetchData, refreshInterval)
+  }
+
+  componentWillUnmount () {
+    clearInterval(this.interval)
+  }
+
+  fetchData () {
+    const {
+      campaign,
+      charity,
+      page,
+      sort,
+      team
+    } = this.props
+
+    fetchDonationFeed({
+      campaign,
+      charity,
+      page,
+      sort,
+      team
+    })
+      .then(donations => donations.map(deserializeDonation))
+      .then(donations => donations.filter(donation => !donation.anonymous))
+      .then(donations => donations.map(donation => this.formatDonation(donation)))
+      .then(donations => this.setState({ donations, status: 'fetched' }))
+      .catch(() => this.setState({ status: 'failed' }))
+  }
+
+  formatDonation (donation) {
+    const { layout, format } = this.props
+    const formattedAmount = numbro(donation.amount).formatCurrency(format)
+
+    switch (layout) {
+      case 'name-only':
+        return donation.name
+      case 'amount-only':
+        return formattedAmount
+      case 'amount-name':
+        return <span><strong>{formattedAmount}</strong> {donation.name}</span>
+      default:
+        return <span>{donation.name} <strong>{formattedAmount}</strong></span>
+    }
+  }
+
+  render () {
+    const {
+      label,
+      ticker
+    } = this.props
+
+    const {
+      donations,
+      status
+    } = this.state
+
+    return status === 'fetched' ? (
+      <Ticker label={label} items={donations} {...ticker} />
+    ) : status === 'failed' ? (
+      <Metric icon='warning' label='An error occurred' />
+    ) : (
+      <Loading />
+    )
+  }
+}
+
+DonationTicker.propTypes = {
+  /**
+  * The campaign uid to fetch totals for
+  */
+  campaign: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.array
+  ]),
+
+  /**
+  * The charity uid to fetch totals for
+  */
+  charity: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.array
+  ]),
+
+  /**
+  * The page uid to fetch totals for
+  */
+  page: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.array
+  ]),
+
+  /**
+  * The team uid to fetch totals for
+  */
+  team: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.array
+  ]),
+
+  /**
+  * Donation amount format
+  */
+  format: PropTypes.string,
+
+  /**
+  * Donation display format
+  */
+  layout: PropTypes.oneOf(['amount-name', 'name-amount', 'amount-only', 'name-only']),
+
+  /**
+  * Label text
+  */
+  label: PropTypes.string,
+
+  /**
+  * Props to be passed to the Constructicon Ticker component
+  */
+  ticker: PropTypes.object,
+
+  /**
+  * Interval (in milliseconds) to refresh data from API
+  */
+  refreshInterval: PropTypes.number
+}
+
+DonationTicker.defaultProps = {
+  format: '0,0[.]00',
+  layout: 'name-amount',
+  ticker: {}
+}
+
+export default DonationTicker

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -43,6 +43,7 @@ module.exports = {
     {
       name: 'Metrics',
       components: () => ([
+        path.resolve(__dirname, 'source/components/donation-ticker', 'index.js'),
         path.resolve(__dirname, 'source/components/progress-bar', 'index.js'),
         path.resolve(__dirname, 'source/components/total-distance', 'index.js'),
         path.resolve(__dirname, 'source/components/total-donations', 'index.js'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1885,9 +1885,9 @@ constants-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
 
-constructicon@^1.7.4:
-  version "1.7.4"
-  resolved "https://registry.yarnpkg.com/constructicon/-/constructicon-1.7.4.tgz#6a93a728fdbe4f5f2362f2cafd9d86b985dbc70e"
+constructicon@^1.7.6:
+  version "1.7.6"
+  resolved "https://registry.yarnpkg.com/constructicon/-/constructicon-1.7.6.tgz#2fbb92071b5b99bc812aa9ff3244232bd8dd826a"
   dependencies:
     cxsync "^1.0.9"
     lodash "^4.17.4"


### PR DESCRIPTION
- Add JG support for `fetchDonationFeed` and `deserializeDonation` methods

  `fetchDonationFeed` really only has support for a JG fundrasing page right now.
  You can pass a charity UID but it only returns the _top 4 promoted donations_, whatever that means...

- Add `DonationTicker` component which fetches data and displays with the the c11n `Ticker` component