### PR TITLE
 Pass JG Authorization header type as param

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/me/justgiving/index.js
+++ b/source/api/me/justgiving/index.js
@@ -54,11 +54,12 @@ export const deserializeUser = (user) => ({
 })
 
 export const fetchCurrentUser = ({
-  token = required()
+  token = required(),
+  authType = 'Basic'
 }) => (
   get('v1/account', {}, {}, {
     headers: {
-      'Authorization': `Basic ${token}`
+      'Authorization': [authType, token].join(' ')
     }
   })
 )
@@ -67,6 +68,7 @@ export const updateCurrentUser = ({
   token = required(),
   userId = required(),
   email = required(),
+  authType = 'Basic',
   firstName,
   lastName,
   address
@@ -78,7 +80,7 @@ export const updateCurrentUser = ({
     address
   }, {
     headers: {
-      'Authorization': `Basic ${token}`
+      'Authorization': [authType, token].join(' ')
     }
   })
 )

--- a/source/api/pages/justgiving/index.js
+++ b/source/api/pages/justgiving/index.js
@@ -53,6 +53,7 @@ export const createPage = ({
   slug = required(),
   title = required(),
   token = required(),
+  authType = 'Basic',
   activityType,
   attribution,
   causeId,
@@ -103,7 +104,7 @@ export const createPage = ({
     videos
   }, {
     headers: {
-      'Authorization': `Basic ${token}`
+      'Authorization': [authType, token].join(' ')
     }
   })
 }

--- a/source/api/teams/justgiving/index.js
+++ b/source/api/teams/justgiving/index.js
@@ -19,6 +19,7 @@ export const fetchTeam = (id = required()) => {
 }
 
 export const createTeam = ({
+  authType = 'Basic',
   name = required(),
   slug = required(),
   story = required(),
@@ -36,12 +37,13 @@ export const createTeam = ({
     teamType
   }, {
     headers: {
-      'Authorization': `Basic ${token}`
+      'Authorization': [authType, token].join(' ')
     }
   })
 }
 
 export const joinTeam = ({
+  authType = 'Basic',
   id = required(),
   page = required(),
   token = required()
@@ -50,7 +52,7 @@ export const joinTeam = ({
     pageShortName: page
   }, {
     headers: {
-      'Authorization': `Basic ${token}`
+      'Authorization': [authType, token].join(' ')
     }
   })
 }


### PR DESCRIPTION
Previously we only supported the authenticated [JG v1 API endpoints](https://developer.justgiving.com/apidocs/endpoints) using `Basic` auth. Now that we're implementing JG OAuth, we need to be able to set the token type as `Bearer`