### PR TITLE
JG pages API updates

### DIFF
--- a/source/api/feeds/justgiving/index.js
+++ b/source/api/feeds/justgiving/index.js
@@ -1,6 +1,6 @@
-import moment from 'moment'
 import { get } from '../../../utils/client'
 import { getShortName, getUID } from '../../../utils/params'
+import jsonDate from '../../../utils/jsonDate'
 
 export const fetchDonationFeed = ({ charity, page }) => {
   if (!charity && !page) {
@@ -17,7 +17,7 @@ export const fetchDonationFeed = ({ charity, page }) => {
 export const deserializeDonation = donation => ({
   amount: donation.donorLocalAmount || donation.amount,
   anonymous: !donation.donorDisplayName || donation.donorDisplayName.toLowerCase().trim() === 'anonymous',
-  createdAt: moment.isMoment(moment(donation.donationDate)) && moment(donation.donationDate).toISOString(),
+  createdAt: jsonDate(donation.donationDate),
   currency: donation.donorLocalCurrencyCode || donation.currencyCode,
   message: donation.message,
   name: donation.donorDisplayName

--- a/source/api/pages/__tests__/update-page-test.js
+++ b/source/api/pages/__tests__/update-page-test.js
@@ -11,7 +11,7 @@ describe('Page | Update Page', () => {
     moxios.uninstall(instance)
   })
 
-  describe('Create EDH Page', () => {
+  describe('Update EDH Page', () => {
     it('throws if no token is passed', () => {
       const test = () => updatePage(123, {
         bogus: 'data'
@@ -62,7 +62,7 @@ describe('Page | Update Page', () => {
     })
   })
 
-  describe('Create JG Page', () => {
+  describe('Update JG Page', () => {
     beforeEach(() => {
       updateClient({ baseURL: 'https://api.justgiving.com' })
     })
@@ -116,7 +116,7 @@ describe('Page | Update Page', () => {
           moxios.requests.at(moxios.requests.count() - 1).url
         ]
 
-        expect(requests).to.include('https://api.justgiving.com/v1/fundraising/pages/page-slug')
+        expect(requests).to.include('https://api.justgiving.com/v1/fundraising/pages/page-slug/pagestory')
         expect(requests).to.include('https://api.justgiving.com/v1/fundraising/pages/page-slug/attribution')
         expect(requests).to.include('https://api.justgiving.com/v1/fundraising/pages/page-slug/images')
         done()

--- a/source/api/pages/justgiving/index.js
+++ b/source/api/pages/justgiving/index.js
@@ -1,6 +1,6 @@
 import moment from 'moment'
 import lodashGet from 'lodash/get'
-import { get, post, put } from '../../../utils/client'
+import { get, put } from '../../../utils/client'
 import { getUID, required } from '../../../utils/params'
 import jsonDate from '../../../utils/jsonDate'
 
@@ -121,18 +121,23 @@ export const createPage = ({
 
 export const updatePage = (slug = required(), {
   token = required(),
+  authType = 'Basic',
   attribution,
   image,
+  name,
   story,
   summaryWhat,
-  summaryWhy
+  summaryWhy,
+  target
 }) => {
-  const config = { headers: { 'Authorization': `Basic ${token}` } }
+  const config = { headers: { 'Authorization': [authType, token].join(' ') } }
 
   return Promise.all([
     attribution && put(`/v1/fundraising/pages/${slug}/attribution`, { attribution }, config),
     image && put(`/v1/fundraising/pages/${slug}/images`, { url: image, isDefault: true }, config),
-    story && post(`/v1/fundraising/pages/${slug}`, { storySupplement: story }, config),
+    name && put(`/v1/fundraising/pages/${slug}/pagetitle`, { pageTitle: name }, config),
+    story && put(`/v1/fundraising/pages/${slug}/pagestory`, { story }, config),
+    target && put(`/v1/fundraising/pages/${slug}/pagetarget`, { target }, config),
     (summaryWhat || summaryWhy) && put(`/v1/fundraising/pages/${slug}/summary`, {
       pageSummaryWhat: summaryWhat,
       pageSummaryWhy: summaryWhy

--- a/source/api/pages/justgiving/index.js
+++ b/source/api/pages/justgiving/index.js
@@ -1,25 +1,35 @@
+import moment from 'moment'
+import lodashGet from 'lodash/get'
 import { get, post, put } from '../../../utils/client'
 import { getUID, required } from '../../../utils/params'
+import jsonDate from '../../../utils/jsonDate'
 
-export const deserializePage = (page) => ({
-  active: null,
-  campaign: null,
-  campaignDate: null,
-  charity: null,
-  coordinates: null,
-  donatationUrl: null,
-  expired: null,
-  groups: null,
-  id: page.Id,
-  image: page.Logo,
-  name: page.Name,
-  raised: page.Amount,
-  story: page.ProfileWhy,
-  target: page.TargetAmount,
-  teamPageId: null,
-  url: page.Link,
-  uuid: null
-})
+export const deserializePage = (page) => {
+  const url = page.Link || `https://${page.domain || 'www.justgiving.com'}/${page.pageShortName}`
+
+  return {
+    active: page.status === 'Active',
+    campaign: page.eventId || page.EventId,
+    campaignDate: jsonDate(page.eventDate) || page.EventDate,
+    charity: page.charity || page.CharityId,
+    coordinates: null,
+    createdAt: jsonDate(page.createdDate) || page.CreatedDate,
+    donationUrl: [url, 'donate'].join('/'),
+    expired: jsonDate(page.expiryDate) && moment(page.expiryDate).isBefore(),
+    groups: null,
+    id: page.pageId || page.Id,
+    image: page.defaultImage || page.Logo || lodashGet(page, 'image.url'),
+    name: page.title || page.Name,
+    owner: page.owner || page.OwnerFullName,
+    raised: parseFloat(page.grandTotalRaisedExcludingGiftAid || page.Amount || 0),
+    slug: page.pageShortName,
+    story: page.story || page.ProfileWhat || page.ProfileWhy,
+    target: parseFloat(page.fundraisingTarget || page.TargetAmount || 0),
+    teamPageId: null,
+    url,
+    uuid: null
+  }
+}
 
 export const fetchPages = (params = required()) => {
   const {

--- a/source/utils/jsonDate/index.js
+++ b/source/utils/jsonDate/index.js
@@ -1,0 +1,4 @@
+import moment from 'moment'
+
+export default date =>
+  moment.isMoment(moment(date)) && moment(date).toISOString()


### PR DESCRIPTION
Previously the `deserializePage` method for JG only took into account the `/v1/onesearch` response. It didn't cater for the `v1/event/:event/leaderboard` or `/v1/fundraising/page/:page` responses, which include more thorough information.

Also the `updatePage` method was missing some available methods not documented [here](https://api.justgiving.com/docs/resources/v1/Fundraising), but are documented [here](https://developer.justgiving.com/apidocs/endpoints/). 😖