### PR TITLE
Deserialize page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "2.12.10",
+  "version": "2.12.11",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/pages/justgiving/index.js
+++ b/source/api/pages/justgiving/index.js
@@ -8,7 +8,7 @@ export const deserializePage = (page) => {
   const url = page.Link || `https://${page.domain || 'www.justgiving.com'}/fundraising/${page.pageShortName}`
 
   return {
-    active: page.status === 'Active',
+    active: [page.status, page.pageStatus].indexOf('Active') > -1,
     campaign: page.eventId || page.EventId,
     campaignDate: jsonDate(page.eventDate) || page.EventDate,
     charity: page.charity || page.CharityId,
@@ -18,13 +18,13 @@ export const deserializePage = (page) => {
     expired: jsonDate(page.expiryDate) && moment(page.expiryDate).isBefore(),
     groups: null,
     id: page.pageId || page.Id,
-    image: page.defaultImage || page.Logo || lodashGet(page, 'image.url'),
-    name: page.title || page.Name,
+    image: page.defaultImage || page.Logo || lodashGet(page, 'image.url') || lodashGet(page, 'images[0].url'),
+    name: page.title || page.pageTitle || page.Name,
     owner: page.owner || page.OwnerFullName,
-    raised: parseFloat(page.grandTotalRaisedExcludingGiftAid || page.Amount || 0),
+    raised: parseFloat(page.grandTotalRaisedExcludingGiftAid || page.Amount || page.raisedAmount || 0),
     slug: page.pageShortName,
     story: page.story || page.ProfileWhat || page.ProfileWhy,
-    target: parseFloat(page.fundraisingTarget || page.TargetAmount || 0),
+    target: parseFloat(page.fundraisingTarget || page.TargetAmount || page.targetAmount || 0),
     teamPageId: null,
     url,
     uuid: null


### PR DESCRIPTION
There are differences in the API response between `GET /v1/fundraising/pages` and `GET /v1/fundraising/pages/:page` that were not previously taken into account.