### PR TITLE
Defensively get distance for metric types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/components/total-distance/index.js
+++ b/source/components/total-distance/index.js
@@ -60,15 +60,26 @@ class TotalDistance extends Component {
     }
   }
 
+  getDistanceForActivityType (overview, type) {
+    const metrics = overview[type]
+    return metrics ? metrics.distance_in_meters : 0
+  }
+
   calculateTotal (data) {
     const { activity } = this.props
     switch (typeof activity) {
       case 'string':
-        return data.fitness_activity_overview[activity].distance_in_meters
+        return this.getDistanceForActivityType(
+          data.fitness_activity_overview,
+          activity
+        )
       case 'object':
         return activity.reduce(
           (total, type) =>
-            (total += data.fitness_activity_overview[type].distance_in_meters),
+            (total += this.getDistanceForActivityType(
+              data.fitness_activity_overview,
+              type
+            )),
           0
         )
       default:


### PR DESCRIPTION
**Problem**

If there was nothing logged for a particular type, the `fitness_activity_overview` object would exclude the key altogether, which means we were getting `Cannot read distance_in_meters of undefined` errors.

**Solution**

Be a bit more defensive to check if the value exists and just return 0 if it doesn't.