### PR TITLE
Address/Country Changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/components/create-page-form/index.js
+++ b/source/components/create-page-form/index.js
@@ -153,8 +153,8 @@ class CreatePageForm extends Component {
       : Promise.resolve()
   }
 
-  handleAddressLookup (address, country) {
-    this.props.form.updateValues({ ...address, country })
+  handleAddressLookup (address) {
+    this.props.form.updateValues(address)
     this.setState({ manualAddress: true })
   }
 
@@ -254,13 +254,15 @@ class CreatePageForm extends Component {
         <GridColumn>
           <InputField {...form.fields.locality} {...inputField} />
         </GridColumn>
-        <GridColumn md={4}>
+        <GridColumn md={country ? 6 : 4}>
           <InputField {...form.fields.region} {...inputField} />
         </GridColumn>
-        <GridColumn md={4}>
-          <InputSelect {...form.fields.country} {...inputField} />
-        </GridColumn>
-        <GridColumn md={4}>
+        {!country && (
+          <GridColumn md={4}>
+            <InputSelect {...form.fields.country} {...inputField} />
+          </GridColumn>
+        )}
+        <GridColumn md={country ? 6 : 4}>
           <InputField {...form.fields.postCode} {...inputField} />
         </GridColumn>
       </Grid>


### PR DESCRIPTION
There was a bug where the CreatePageForm was not setting the country correctly, as it was expecting the address as the first argument, and the country as the second. But it actually just comes back from AddressSearch as a single object, with the country one of the fields.

Secondly, if the country prop is set, this means the form should not show the country field. It already does this in the address search part of it, but then when the manual fields are shown, there is still the country field.