### PR TITLE
Add helpers to get number of donations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/leaderboard/everydayhero/index.js
+++ b/source/api/leaderboard/everydayhero/index.js
@@ -30,17 +30,18 @@ export const fetchLeaderboard = (params = required()) => {
  */
 export const deserializeLeaderboard = (result, index) => {
   if (result.page) {
-    return deserializePage(result.page, index)
+    return deserializePage(result.page, index, result)
   } else if (result.team) {
-    return deserializePage(result.team, index)
+    return deserializePage(result.team, index, result)
   } else if (result.group) {
     return deserializeGroup(result, index)
   }
 }
 
-const deserializePage = (item, index) => ({
+const deserializePage = (item, index, baseItem) => ({
   currency: item.amount.currency.iso_code,
   currencySymbol: item.amount.currency.symbol,
+  donationCount: baseItem.count,
   groups: item.group_values,
   id: item.id,
   image: item.image.large_image_url,
@@ -51,6 +52,7 @@ const deserializePage = (item, index) => ({
   slug: item.url && last(item.url.split('/')),
   subtitle: item.charity_name,
   target: item.target_cents / 100,
+  totalDonations: baseItem.count,
   url: item.url
 })
 

--- a/source/api/pages/__tests__/fetch-test.js
+++ b/source/api/pages/__tests__/fetch-test.js
@@ -1,5 +1,5 @@
 import moxios from 'moxios'
-import { fetchPages, fetchPage } from '..'
+import { fetchPages, fetchPage, fetchPageDonationCount } from '..'
 import { instance, updateClient } from '../../../utils/client'
 
 describe('Fetch Pages', () => {
@@ -85,6 +85,25 @@ describe('Fetch Pages', () => {
         expect(test).to.throw
       })
     })
+
+    describe('Fetch a single page donation count', () => {
+      it('uses the correct url to fetch donation count', done => {
+        fetchPageDonationCount('1234')
+
+        moxios.wait(() => {
+          const request = moxios.requests.mostRecent()
+          expect(request.url).to.contain(
+            'https://everydayhero.com/api/v2/pages/1234'
+          )
+          done()
+        })
+      })
+
+      it('throws if no id is passed in', () => {
+        const test = () => fetchPageDonationCount()
+        expect(test).to.throw
+      })
+    })
   })
 
   describe('Fetch JG Pages', () => {
@@ -152,6 +171,25 @@ describe('Fetch Pages', () => {
 
       it('throws if no id is passed in', () => {
         const test = () => fetchPage()
+        expect(test).to.throw
+      })
+    })
+
+    describe('Fetch a single page donation count', () => {
+      it('uses the correct url to fetch a donation count', done => {
+        fetchPageDonationCount('my-page-shortname')
+
+        moxios.wait(() => {
+          const request = moxios.requests.mostRecent()
+          expect(request.url).to.equal(
+            'https://api.justgiving.com/v1/fundraising/pages/my-page-shortname/donations'
+          )
+          done()
+        })
+      })
+
+      it('throws if no id is passed in', () => {
+        const test = () => fetchPageDonationCount()
         expect(test).to.throw
       })
     })

--- a/source/api/pages/everydayhero/index.js
+++ b/source/api/pages/everydayhero/index.js
@@ -67,6 +67,10 @@ export const fetchPage = (id = required()) => {
   return get(`api/v2/pages/${id}`).then(response => response.page)
 }
 
+export const fetchPageDonationCount = (id = required()) => {
+  return get(`/api/v2/pages/${id}`).then(data => data.total_donations)
+}
+
 export const createPage = ({
   token = required(),
   campaignId = required(),

--- a/source/api/pages/index.js
+++ b/source/api/pages/index.js
@@ -4,6 +4,7 @@ import {
   deserializePage as deserializeEDHPage,
   fetchPages as fetchEDHPages,
   fetchPage as fetchEDHPage,
+  fetchPageDonationCount as fetchEDHPageDonationCount,
   createPage as createEDHPage,
   updatePage as updateEDHPage
 } from './everydayhero'
@@ -12,6 +13,7 @@ import {
   deserializePage as deserializeJGPage,
   fetchPages as fetchJGPages,
   fetchPage as fetchJGPage,
+  fetchPageDonationCount as fetchJGPageDonationCount,
   createPage as createJGPage,
   updatePage as updateJGPage
 } from './justgiving'
@@ -33,6 +35,14 @@ export const fetchPages = params =>
  */
 export const fetchPage = page =>
   isJustGiving() ? fetchJGPage(page) : fetchEDHPage(page)
+
+/**
+ * @function fetches a page's donation count
+ */
+export const fetchPageDonationCount = page =>
+  isJustGiving()
+    ? fetchJGPageDonationCount(page)
+    : fetchEDHPageDonationCount(page)
 
 /**
  * @function create page

--- a/source/api/pages/justgiving/index.js
+++ b/source/api/pages/justgiving/index.js
@@ -112,6 +112,12 @@ export const fetchPage = (page = required()) => {
   return get(`/v1/fundraising/${endpoint}/${page}`)
 }
 
+export const fetchPageDonationCount = (page = required()) => {
+  return get(`/v1/fundraising/pages/${page}/donations`).then(
+    data => data.pagination.totalResults
+  )
+}
+
 export const createPage = ({
   charityId = required(),
   charityOptIn = required(),

--- a/source/api/pages/readme.md
+++ b/source/api/pages/readme.md
@@ -3,6 +3,8 @@
 Helpers related to fetching supporter pages
 
 - [fetchPages](#fetchpages)
+- [fetchPage](#fetchpage)
+- [fetchPageDonationCount](#fetchpagedonationcount)
 - [deserializePage](#deserializepage)
 - [createPage](#createpage)
 - [updatePage](#updatepage)
@@ -34,6 +36,56 @@ import { fetchPages } from 'supporticon/api/pages'
 fetchPages({
   campaign: 'au-123'
 })
+```
+
+## `fetchPage`
+
+**Purpose**
+
+Fetch a single page.
+
+**Params**
+
+- `id` - the page id
+
+**Returns**
+
+A pending promise that will either resolve to:
+
+- Success: the page data
+- Failure: the error encountered
+
+**Example**
+
+```javascript
+import { fetchPage } from 'supporticon/api/pages'
+
+fetchPage('12345')
+```
+
+## `fetchPageDonationCount`
+
+**Purpose**
+
+Fetch a single page's donation count.
+
+**Params**
+
+- `id` - the page id
+
+**Returns**
+
+A pending promise that will either resolve to:
+
+- Success: the number of donations received by that page
+- Failure: the error encountered
+
+**Example**
+
+```javascript
+import { fetchPage } from 'supporticon/api/pages'
+
+fetchPage('12345')
 ```
 
 ## `deserializePage`


### PR DESCRIPTION
- Added the donation count to the leaderboard deserializer
- Added a new `fetchPageDonationCount` helper so we can fetch a donation count for a single page, mainly for JG as it is only available on a separate endpoint
- Document the new helper, as well as `fetchPage`, which was undocumented 🤷‍♂️ 