### PR TITLE
Exclude pages from fitness leaderboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/components/fitness-leaderboard/index.js
+++ b/source/components/fitness-leaderboard/index.js
@@ -60,6 +60,7 @@ class FitnessLeaderboard extends Component {
       endDate,
       includeManual,
       excludeVirtual,
+      excludePageIds,
       limit,
       page,
       groupID,
@@ -83,16 +84,19 @@ class FitnessLeaderboard extends Component {
       endDate,
       include_manual: includeManual,
       exclude_virtual: excludeVirtual,
-      limit,
+      limit: limit + 10,
       page,
       groupID,
       sortBy,
       q
     })
+      .then(data => data.map(deserializeFitnessLeaderboard))
+      .then(data => this.removeExcludedPages(excludePageIds, data))
+      .then(data => data.slice(0, limit))
       .then(data => {
         this.setState({
           status: 'fetched',
-          data: data.map(deserializeFitnessLeaderboard)
+          data
         })
       })
       .catch(error => {
@@ -101,6 +105,14 @@ class FitnessLeaderboard extends Component {
         })
         return Promise.reject(error)
       })
+  }
+
+  removeExcludedPages (excludePageIds, pages) {
+    return excludePageIds
+      ? pages.filter(
+        page => excludePageIds.split(',').indexOf(page.id.toString()) === -1
+      )
+      : pages
   }
 
   render () {


### PR DESCRIPTION
The fundraising leaderboards endpoint has an `exclude_page_ids` param, which we use to hide pages from a leaderboard. In site builder, we have this field also for fitness leaderboards, but the fitness leaderboard endpoint doesn't have this param, so the field effectively does nothing. I added this param to the fitness leaderboard component, so it fetches more pages than required, filters out any ones that needs to be removed, and then slices the array to the appropriate length.