### PR TITLE
JG Campaign leaderboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.4.8",
+  "version": "3.5.0",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/leaderboard/__tests__/fetch-test.js
+++ b/source/api/leaderboard/__tests__/fetch-test.js
@@ -1,5 +1,5 @@
 import moxios from 'moxios'
-import { instance, updateClient } from '../../../utils/client'
+import { instance, servicesAPI, updateClient } from '../../../utils/client'
 import { fetchLeaderboard } from '..'
 import { fetchLeaderboard as fetchJGLeaderboard } from '../justgiving'
 import { fetchLeaderboard as fetchEDHLeaderboard } from '../everydayhero'
@@ -120,11 +120,13 @@ describe('Fetch Leaderboards', () => {
         headers: { 'x-api-key': 'abcd1234' }
       })
       moxios.install(instance)
+      moxios.install(servicesAPI)
     })
 
     afterEach(() => {
       updateClient({ baseURL: 'https://everydayhero.com' })
       moxios.uninstall(instance)
+      moxios.uninstall(servicesAPI)
     })
 
     it('throws if no params are passed in', () => {
@@ -133,13 +135,13 @@ describe('Fetch Leaderboards', () => {
     })
 
     it('uses the correct url to fetch a campaign leaderboard', done => {
-      fetchJGLeaderboard({ charity: 'my-charity', campaign: 'my-campaign' })
+      fetchJGLeaderboard({ campaign: 'my-campaign', page: 2 })
       moxios.wait(() => {
         const request = moxios.requests.mostRecent()
         expect(request.url).to.contain(
-          'https://api.justgiving.com/v1/campaigns/my-charity/my-campaign/pages'
+          'https://api.blackbaud.services/v1/justgiving/campaigns/my-campaign/leaderboard'
         )
-        expect(request.url).to.contain('pageSize=100')
+        expect(request.url).to.contain('page=2')
         done()
       })
     })

--- a/source/utils/client/index.js
+++ b/source/utils/client/index.js
@@ -36,6 +36,8 @@ export const updateClient = (options = {}) => {
   Object.keys(options).map(option => {
     instance.defaults[option] = options[option]
   })
+
+  updateServicesAPIClient()
 }
 
 export const getBaseURL = () => instance.defaults.baseURL
@@ -44,6 +46,18 @@ export const getPlatform = () =>
   /justgiving/.test(instance.defaults.baseURL) ? 'justgiving' : 'everydayhero'
 
 export const isJustGiving = () => /justgiving/.test(instance.defaults.baseURL)
+export const isStaging = () => /staging/.test(instance.defaults.baseURL)
+
+// Services API Client
+export const servicesAPI = axios.create({
+  baseURL: 'https://api.blackbaud.services'
+})
+
+const updateServicesAPIClient = () => {
+  servicesAPI.defaults.baseURL = isStaging()
+    ? 'https://api-staging.blackbaud.services'
+    : 'https://api.blackbaud.services'
+}
 
 export default {
   instance,
@@ -54,5 +68,7 @@ export default {
   updateClient,
   getBaseURL,
   getPlatform,
-  isJustGiving
+  isJustGiving,
+  isStaging,
+  servicesAPI
 }

--- a/source/utils/params/index.js
+++ b/source/utils/params/index.js
@@ -15,12 +15,10 @@ export const dataSource = ({ event, charity, campaign }) => {
     }
 
     return 'charity'
-  } else {
-    if (!charity || !campaign) {
-      return required()
-    }
-
+  } else if (campaign) {
     return 'campaign'
+  } else {
+    return required()
   }
 }
 


### PR DESCRIPTION
The tricky part of this was that it introduced the services API as another target. It wasn't straightforward as it has staging vs production, but both of those environments support JG and EDH (not that there are EDH methods there yet, but there could be). I wanted to keep it abstracted, so the consuming app didn't have to specify which version of the services API it wanted to talk to. So whenever the baseURL is updated, it detects whether it is staging or prod, and updates the services API client accordingly.