### PR TITLE
Increase support for v2 campaigns

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/campaigns/__tests__/campaigns-test.js
+++ b/source/api/campaigns/__tests__/campaigns-test.js
@@ -105,38 +105,24 @@ describe('Fetch Campaigns', () => {
       moxios.uninstall(instance)
     })
 
-    it('fetches campaigns using the provided params', done => {
-      fetchCampaigns({ charity: 'my-charity' })
-      moxios.wait(() => {
-        const request = moxios.requests.mostRecent()
-        expect(request.url).to.contain(
-          'https://api.justgiving.com/v1/campaigns'
-        )
-        expect(request.url).to.contain('my-charity')
-        done()
-      })
-    })
-
-    it('throws if campaigns are requested, but no parameters are provided', () => {
-      const test = () => fetchCampaigns()
-      expect(test).to.throw
-    })
-
     it('fetches a single campaign', done => {
-      fetchCampaign({ charity: 'my-charity', campaign: 'my-campaign' })
+      fetchCampaign('my-campaign')
       moxios.wait(() => {
         const request = moxios.requests.mostRecent()
-        expect(request.url).to.contain(
-          'https://api.justgiving.com/v1/campaigns'
+        expect(request.url).to.equal(
+          'https://api.justgiving.com/campaigns/v2/campaign/my-campaign'
         )
-        expect(request.url).to.contain('my-charity')
-        expect(request.url).to.contain('my-campaign')
         done()
       })
     })
 
     it('throws if a campaign is requested, but no campaign id is supplied', () => {
       const test = () => fetchCampaign()
+      expect(test).to.throw
+    })
+
+    it('throws if multiple campaigns are requested', () => {
+      const test = () => fetchCampaigns({ charity: 'foo' })
       expect(test).to.throw
     })
 

--- a/source/api/campaigns/everydayhero/index.js
+++ b/source/api/campaigns/everydayhero/index.js
@@ -36,10 +36,15 @@ export const fetchCampaignGroups = (id = required()) =>
 
 export const deserializeCampaign = campaign => ({
   name: campaign.name,
+  summary: campaign.description,
   id: campaign.id,
   uuid: campaign.uuid,
   slug: campaign.slug,
   url: campaign.url,
+  target: null,
+  raised: campaign.fundsRaised.cents / 100,
+  raisedOffline: null,
+  totalDonations: null,
   getStartedUrl: campaign.get_started_url,
   donateUrl: campaign.donate_url
 })

--- a/source/api/campaigns/justgiving/index.js
+++ b/source/api/campaigns/justgiving/index.js
@@ -1,33 +1,26 @@
 import { get } from '../../../utils/client'
-import { getShortName, required } from '../../../utils/params'
+import { required } from '../../../utils/params'
 
-export const c = {
-  ENDPOINT: 'v1/campaigns'
-}
+export const fetchCampaigns = () =>
+  Promise.reject(new Error('This is method is not supported for JustGiving'))
 
-export const fetchCampaigns = (params = required()) =>
-  get(`${c.ENDPOINT}/${getShortName(params.charity)}`).then(
-    response => response.campaignsDetails
-  )
-
-export const fetchCampaign = ({
-  charity = required(),
-  campaign = required()
-}) => get(`${c.ENDPOINT}/${getShortName(charity)}/${getShortName(campaign)}`)
+export const fetchCampaign = (id = required()) =>
+  get(`/campaigns/v2/campaign/${id}`)
 
 export const fetchCampaignGroups = (id = required()) =>
-  Promise.reject('This method is not supported for JustGiving')
+  Promise.reject(new Error('This method is not supported for JustGiving'))
 
 export const deserializeCampaign = campaign => {
-  const { id, campaignUrl, causeId } = campaign
-  const slug = campaignUrl.split('/')[campaignUrl.split('/').length - 1]
-
   return {
-    name: campaign.campaignPageName,
-    id,
-    slug,
-    url: campaignUrl,
-    getStartedUrl: `https://www.justgiving.com/fundraising-page/creation/?cid=${id}&causeId=${causeId}`,
-    donateUrl: `https://link.justgiving.com/v1/campaign/donate/campaignId/${id}`
+    name: campaign.title,
+    summary: campaign.summary,
+    id: campaign.campaignGuid,
+    slug: campaign.shortName,
+    target: campaign.targetAmount,
+    raised: campaign.donationSummary.totalAmount,
+    raisedOffline: campaign.donationSummary.offlineAmount,
+    totalDonations: campaign.donationSummary.totalNumberOfDonations,
+    getStartedUrl: null,
+    donateUrl: null
   }
 }

--- a/source/api/donation-totals/__tests__/totals-test.js
+++ b/source/api/donation-totals/__tests__/totals-test.js
@@ -89,11 +89,11 @@ describe('Fetch Donation Totals', () => {
     })
 
     it('uses the correct url to fetch totals for a campaign', done => {
-      fetchJGDonationTotals({ charity: 'my-charity', campaign: 'my-campaign' })
+      fetchJGDonationTotals({ campaign: 'my-campaign' })
       moxios.wait(() => {
         const request = moxios.requests.mostRecent()
         expect(request.url).to.equal(
-          'https://api.justgiving.com/v1/campaigns/my-charity/my-campaign'
+          'https://api.justgiving.com/campaigns/v2/campaign/my-campaign'
         )
         done()
       })

--- a/source/api/donation-totals/justgiving/index.js
+++ b/source/api/donation-totals/justgiving/index.js
@@ -1,31 +1,30 @@
-import { get } from '../../../utils/client'
-import {
-  getShortName,
-  getUID,
-  required,
-  dataSource
-} from '../../../utils/params'
+import client from '../../../utils/client'
+import get from 'lodash/get'
+import { getUID, required, dataSource } from '../../../utils/params'
 import { currencyCode } from '../../../utils/currencies'
 
 export const fetchDonationTotals = (params = required()) => {
   switch (dataSource(params)) {
     case 'event':
-      return get(`v1/event/${getUID(params.event)}/leaderboard`, {
+      return client.get(`v1/event/${getUID(params.event)}/leaderboard`, {
         currency: currencyCode(params.country)
       })
     case 'charity':
       // No API method supports total funds raised for a charity
       return required()
     default:
-      return get(
-        `v1/campaigns/${getShortName(params.charity)}/${getShortName(
-          params.campaign
-        )}`
-      )
+      return client.get(`campaigns/v2/campaign/${getUID(params.campaign)}`)
   }
 }
 
 export const deserializeDonationTotals = totals => ({
-  raised: totals.totalRaised || totals.raisedAmount || 0,
-  donations: totals.numberOfDirectDonations || 0
+  raised:
+    totals.totalRaised ||
+    totals.raisedAmount ||
+    get(totals, 'donationSummary.totalAmount') ||
+    0,
+  donations:
+    totals.numberOfDirectDonations ||
+    get(totals, 'donationSummary.totalNumberOfDonations') ||
+    0
 })

--- a/source/api/leaderboard/justgiving/index.js
+++ b/source/api/leaderboard/justgiving/index.js
@@ -54,7 +54,9 @@ export const fetchLeaderboard = (params = required()) => {
 export const deserializeLeaderboard = (supporter, index) => ({
   currency: supporter.currencyCode,
   currencySymbol: supporter.currencySymbol,
-  donationUrl: `https://www.justgiving.com/${supporter.pageShortName}/donate`,
+  donationUrl: `https://www.justgiving.com/fundraising/${
+    supporter.pageShortName
+  }/donate`,
   id: supporter.pageId,
   image:
     supporter.defaultImage ||

--- a/source/api/pages-totals/__tests__/totals-test.js
+++ b/source/api/pages-totals/__tests__/totals-test.js
@@ -1,5 +1,5 @@
 import moxios from 'moxios'
-import { instance, updateClient } from '../../../utils/client'
+import { instance, servicesAPI, updateClient } from '../../../utils/client'
 import { fetchPagesTotals } from '..'
 import { fetchPagesTotals as fetchEDHPagesTotals } from '../everydayhero'
 import { fetchPagesTotals as fetchJGPagesTotals } from '../justgiving'
@@ -59,11 +59,13 @@ describe('Fetch Pages Totals', () => {
         headers: { 'x-api-key': 'abcd1234' }
       })
       moxios.install(instance)
+      moxios.install(servicesAPI)
     })
 
     afterEach(() => {
       updateClient({ baseURL: 'https://everydayhero.com' })
       moxios.uninstall(instance)
+      moxios.uninstall(servicesAPI)
     })
 
     it('uses the correct url to fetch totals for an event', done => {
@@ -72,6 +74,17 @@ describe('Fetch Pages Totals', () => {
         const request = moxios.requests.mostRecent()
         expect(request.url).to.equal(
           'https://api.justgiving.com/v1/event/12345/pages'
+        )
+        done()
+      })
+    })
+
+    it('uses the correct url to fetch totals for a campaign', done => {
+      fetchJGPagesTotals({ campaign: 12345 })
+      moxios.wait(function () {
+        const request = moxios.requests.mostRecent()
+        expect(request.url).to.equal(
+          'https://api.blackbaud.services/v1/justgiving/campaigns/12345/leaderboard'
         )
         done()
       })

--- a/source/api/pages-totals/justgiving/index.js
+++ b/source/api/pages-totals/justgiving/index.js
@@ -1,10 +1,5 @@
-import { get } from '../../../utils/client'
-import {
-  getShortName,
-  getUID,
-  required,
-  dataSource
-} from '../../../utils/params'
+import { get, servicesAPI } from '../../../utils/client'
+import { getUID, required, dataSource } from '../../../utils/params'
 
 export const fetchPagesTotals = (params = required()) => {
   switch (dataSource(params)) {
@@ -16,10 +11,9 @@ export const fetchPagesTotals = (params = required()) => {
       // No API method supports total number of pages for a charity
       return required()
     default:
-      return get(
-        `v1/campaigns/${getShortName(params.charity)}/${getShortName(
-          params.campaign
-        )}/pages`
-      ).then(response => response.totalFundraisingPages)
+      return servicesAPI
+        .get(`/v1/justgiving/campaigns/${getUID(params.campaign)}/leaderboard`)
+        .then(response => response.data)
+        .then(data => data.meta.totalPages)
   }
 }


### PR DESCRIPTION
These are various changes that will allow us to increase support for v2 campaigns in site builder

- fetchCampaign using v2 campaigns API
- get donation totals for a campaign using above endpoint
- get page count for a campaign using leaderboard endpoint (via services api)
- update donation url built in leaderboard deserializer to point to correct location
