### PR TITLE
Recursive leaderboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/leaderboard/__tests__/fetch-test.js
+++ b/source/api/leaderboard/__tests__/fetch-test.js
@@ -135,13 +135,12 @@ describe('Fetch Leaderboards', () => {
     })
 
     it('uses the correct url to fetch a campaign leaderboard', done => {
-      fetchJGLeaderboard({ campaign: 'my-campaign', page: 2 })
+      fetchJGLeaderboard({ campaign: 'my-campaign' })
       moxios.wait(() => {
         const request = moxios.requests.mostRecent()
         expect(request.url).to.contain(
           'https://api.blackbaud.services/v1/justgiving/campaigns/my-campaign/leaderboard'
         )
-        expect(request.url).to.contain('page=2')
         done()
       })
     })


### PR DESCRIPTION
JG campaign leaderboard only returns max 10 pages. This resulted in a bit of inconsistency in the way it was being used. In most cases we just get the array of pages returned, but in the site builder projects, we actually need the metadata to determine whether to get the next page etc.

The best solution was to handle this within Supporticon itself. So you can pass in a limit (defaults to 10), and it will recursively fetch until it has the number of requested pages.