### PR TITLE
Paginate leaderboards

### DIFF
--- a/source/components/fitness-leaderboard/Readme.md
+++ b/source/components/fitness-leaderboard/Readme.md
@@ -34,6 +34,7 @@
   campaign='au-21937'
   type='group'
   groupID={58}
+  excludePageIds={['Sydney, NSW']}
 />
 ```
 

--- a/source/components/fitness-leaderboard/Readme.md
+++ b/source/components/fitness-leaderboard/Readme.md
@@ -8,6 +8,16 @@
 />
 ```
 
+*Paginated Leaderboard*
+
+```
+<FitnessLeaderboard
+  campaign='au-24234'
+  limit={100}
+  pageSize={10}
+/>
+```
+
 *Leaderboard by Team*
 
 ```

--- a/source/components/fitness-leaderboard/Readme.md
+++ b/source/components/fitness-leaderboard/Readme.md
@@ -15,6 +15,7 @@
   campaign='au-24234'
   limit={100}
   pageSize={10}
+  showPage
 />
 ```
 

--- a/source/components/fitness-leaderboard/index.js
+++ b/source/components/fitness-leaderboard/index.js
@@ -1,9 +1,13 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import numbro from 'numbro'
+
 import Filter from 'constructicon/filter'
-import LeaderboardWrapper from 'constructicon/leaderboard'
+import Grid from 'constructicon/grid'
 import LeaderboardItem from 'constructicon/leaderboard-item'
+import LeaderboardWrapper from 'constructicon/leaderboard'
+import Pagination from 'constructicon/pagination'
+import PaginationLink from 'constructicon/pagination-link'
 
 import {
   fetchFitnessLeaderboard,
@@ -117,8 +121,7 @@ class FitnessLeaderboard extends Component {
 
   render () {
     const { status, data = [] } = this.state
-
-    const { leaderboard, filter } = this.props
+    const { leaderboard, filter, pageSize } = this.props
 
     return (
       <div>
@@ -126,9 +129,33 @@ class FitnessLeaderboard extends Component {
         <LeaderboardWrapper
           loading={status === 'fetching'}
           error={status === 'failed'}
-          children={data.map(this.renderLeader)}
           {...leaderboard}
-        />
+        >
+          {data.length && (
+            <Pagination max={pageSize} toPaginate={data}>
+              {({ currentPage, isPaginated, prev, next, canPrev, canNext }) => (
+                <div>
+                  {currentPage.map(this.renderLeader)}
+                  {pageSize &&
+                    isPaginated && (
+                    <Grid justify='center'>
+                      <PaginationLink
+                        onClick={prev}
+                        direction='prev'
+                        disabled={!canPrev}
+                      />
+                      <PaginationLink
+                        onClick={next}
+                        direction='next'
+                        disabled={!canNext}
+                      />
+                    </Grid>
+                  )}
+                </div>
+              )}
+            </Pagination>
+          )}
+        </LeaderboardWrapper>
       </div>
     )
   }
@@ -144,6 +171,7 @@ class FitnessLeaderboard extends Component {
         image={leader.image}
         amount={this.getMetric(leader)}
         href={leader.url}
+        rank={leader.position}
         {...leaderboardItem}
       />
     )
@@ -229,6 +257,11 @@ FitnessLeaderboard.propTypes = {
    * The number of records to fetch
    */
   limit: PropTypes.number,
+
+  /**
+   * The number of records to show per page, disables pagination if not specified.
+   */
+  pageSize: PropTypes.number,
 
   /**
    * The page to fetch

--- a/source/components/fitness-leaderboard/index.js
+++ b/source/components/fitness-leaderboard/index.js
@@ -271,7 +271,7 @@ FitnessLeaderboard.propTypes = {
   /**
    * The group ID to group the leaderboard by (only relevant if type is group)
    */
-  groupID: PropTypes.number,
+  groupID: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
   /**
    * The type of measurement to sort by

--- a/source/components/fitness-leaderboard/index.js
+++ b/source/components/fitness-leaderboard/index.js
@@ -94,8 +94,8 @@ class FitnessLeaderboard extends Component {
       sortBy,
       q
     })
+      .then(data => this.removeExcludedPages(excludePageIds, data, type))
       .then(data => data.map(deserializeFitnessLeaderboard))
-      .then(data => this.removeExcludedPages(excludePageIds, data))
       .then(data => data.slice(0, limit))
       .then(data => {
         this.setState({
@@ -111,12 +111,19 @@ class FitnessLeaderboard extends Component {
       })
   }
 
-  removeExcludedPages (excludePageIds, pages) {
-    return excludePageIds
-      ? pages.filter(
-        page => excludePageIds.split(',').indexOf(page.id.toString()) === -1
-      )
-      : pages
+  removeExcludedPages (excludePageIds, pages, type) {
+    if (!excludePageIds) return pages
+
+    return pages.filter(page => {
+      const item = deserializeFitnessLeaderboard(page)
+      const id = type === 'group' ? item.name : item.id
+
+      const excluded = Array.isArray(excludePageIds)
+        ? excludePageIds
+        : excludePageIds.split(',')
+
+      return excluded.indexOf(id.toString()) === -1
+    })
   }
 
   render () {

--- a/source/components/fitness-leaderboard/index.js
+++ b/source/components/fitness-leaderboard/index.js
@@ -8,6 +8,7 @@ import LeaderboardItem from 'constructicon/leaderboard-item'
 import LeaderboardWrapper from 'constructicon/leaderboard'
 import Pagination from 'constructicon/pagination'
 import PaginationLink from 'constructicon/pagination-link'
+import RichText from 'constructicon/rich-text'
 
 import {
   fetchFitnessLeaderboard,
@@ -128,7 +129,7 @@ class FitnessLeaderboard extends Component {
 
   render () {
     const { status, data = [] } = this.state
-    const { leaderboard, filter, pageSize } = this.props
+    const { leaderboard, filter, pageSize, showPage } = this.props
 
     return (
       <div>
@@ -140,17 +141,26 @@ class FitnessLeaderboard extends Component {
         >
           {data.length && (
             <Pagination max={pageSize} toPaginate={data}>
-              {({ currentPage, isPaginated, prev, next, canPrev, canNext }) => (
+              {({
+                currentPage,
+                isPaginated,
+                prev,
+                next,
+                canPrev,
+                canNext,
+                pageOf
+              }) => (
                 <div>
                   {currentPage.map(this.renderLeader)}
                   {pageSize &&
                     isPaginated && (
-                    <Grid justify='center'>
+                    <Grid align='center' justify='center'>
                       <PaginationLink
                         onClick={prev}
                         direction='prev'
                         disabled={!canPrev}
                       />
+                      {showPage && <RichText size={-1}>{pageOf}</RichText>}
                       <PaginationLink
                         onClick={next}
                         direction='next'
@@ -310,6 +320,7 @@ FitnessLeaderboard.defaultProps = {
   limit: 10,
   page: 1,
   filter: {},
+  showPage: false,
   sortBy: 'distance'
 }
 

--- a/source/components/leaderboard/Readme.md
+++ b/source/components/leaderboard/Readme.md
@@ -14,6 +14,7 @@
   campaign='au-23374'
   limit={50}
   pageSize={10}
+  showPage
 />
 ```
 

--- a/source/components/leaderboard/Readme.md
+++ b/source/components/leaderboard/Readme.md
@@ -12,7 +12,7 @@
 ```
 <Leaderboard
   campaign='au-23374'
-  limit={15}
+  limit={50}
   pageSize={10}
 />
 ```

--- a/source/components/leaderboard/index.js
+++ b/source/components/leaderboard/index.js
@@ -9,6 +9,7 @@ import LeaderboardItem from 'constructicon/leaderboard-item'
 import LeaderboardWrapper from 'constructicon/leaderboard'
 import Pagination from 'constructicon/pagination'
 import PaginationLink from 'constructicon/pagination-link'
+import RichText from 'constructicon/rich-text'
 
 import { fetchLeaderboard, deserializeLeaderboard } from '../../api/leaderboard'
 
@@ -146,7 +147,7 @@ class Leaderboard extends Component {
 
   render () {
     const { status, data = [] } = this.state
-    const { leaderboard, filter, pageSize } = this.props
+    const { leaderboard, filter, pageSize, showPage } = this.props
 
     return (
       <div>
@@ -158,17 +159,26 @@ class Leaderboard extends Component {
         >
           {data.length && (
             <Pagination max={pageSize} toPaginate={data}>
-              {({ currentPage, isPaginated, prev, next, canPrev, canNext }) => (
+              {({
+                currentPage,
+                isPaginated,
+                prev,
+                next,
+                canPrev,
+                canNext,
+                pageOf
+              }) => (
                 <div>
                   {currentPage.map(this.renderLeader)}
                   {pageSize &&
                     isPaginated && (
-                    <Grid justify='center'>
+                    <Grid align='center' justify='center'>
                       <PaginationLink
                         onClick={prev}
                         direction='prev'
                         disabled={!canPrev}
                       />
+                      {showPage && <RichText size={-1}>{pageOf}</RichText>}
                       <PaginationLink
                         onClick={next}
                         direction='next'
@@ -301,6 +311,7 @@ Leaderboard.propTypes = {
 
 Leaderboard.defaultProps = {
   limit: 10,
+  showPage: false,
   page: 1,
   filter: {}
 }

--- a/source/components/leaderboard/index.js
+++ b/source/components/leaderboard/index.js
@@ -261,7 +261,7 @@ Leaderboard.propTypes = {
   /**
    * The group ID to group the leaderboard by (only relevant if type is group)
    */
-  groupID: PropTypes.number,
+  groupID: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
   /**
    * Props to be passed to the Constructicon Leaderboard component

--- a/source/components/leaderboard/index.js
+++ b/source/components/leaderboard/index.js
@@ -51,6 +51,15 @@ class Leaderboard extends Component {
     this.fetchLeaderboard(q)
   }
 
+  removeExcludedGroups (groups, values) {
+    if (!values) return groups
+
+    return groups.filter(item => {
+      const excluded = Array.isArray(values) ? values : values.split(',')
+      return excluded.indexOf(item.group.value.toString()) === -1
+    })
+  }
+
   handleData (data, excludeOffline) {
     const leaderboardData = data.map(deserializeLeaderboard)
 
@@ -103,7 +112,7 @@ class Leaderboard extends Component {
       country,
       endDate,
       event,
-      excludePageIds,
+      excludePageIds: type === 'group' ? undefined : excludePageIds,
       group,
       groupID,
       limit,
@@ -115,6 +124,12 @@ class Leaderboard extends Component {
       startDate,
       type
     })
+      .then(
+        data =>
+          type === 'group'
+            ? this.removeExcludedGroups(data, excludePageIds)
+            : data
+      )
       .then(data => {
         this.setState({
           status: 'fetched',


### PR DESCRIPTION
- Update fundraising leaderboard component to use c11n `Pagination` component
- Add support for pagination to `FitnessLeaderboard` component
- Add support to exclude group values from leaderboards
- Update leaderboard examples to use new/updated props

<img width="759" alt="Screen Shot 2019-07-02 at 12 10 11 pm" src="https://user-images.githubusercontent.com/729085/60477564-e3be5180-9cc2-11e9-8790-39cba3efc5d6.png">