### PR TITLE
Add required asterisks when needed to address fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/components/address-search/index.js
+++ b/source/components/address-search/index.js
@@ -12,6 +12,7 @@ import InputSelect from 'constructicon/input-select'
 import Grid from 'constructicon/grid'
 import GridColumn from 'constructicon/grid-column'
 import InputSearch from 'constructicon/input-search'
+import Section from 'constructicon/section'
 
 class AddressSearch extends Component {
   constructor (props) {
@@ -87,12 +88,17 @@ class AddressSearch extends Component {
   }
 
   renderLabel () {
-    const { onCancel, onCancelLabel } = this.props
+    const { onCancel, onCancelLabel, required } = this.props
 
     return (
       <Grid spacing={{ x: 0.5 }}>
         <GridColumn xs={5}>
           <span>Address</span>
+          {required && (
+            <Section foreground='danger' spacing={0} tag='span'>
+              *
+            </Section>
+          )}
         </GridColumn>
         {onCancel && (
           <GridColumn xs={7} xsAlign='right'>

--- a/source/components/create-page-form/index.js
+++ b/source/components/create-page-form/index.js
@@ -238,6 +238,7 @@ class CreatePageForm extends Component {
           onCancel={() => this.setState({ manualAddress: true })}
           onChange={this.handleAddressLookup}
           inputProps={inputField}
+          required
           validations={form.fields.streetAddress.validations}
         />
       )
@@ -422,23 +423,28 @@ const form = props => {
         label: 'Country',
         initial: props.country,
         options: countries,
+        required: true,
         validators: [validators.required('Please select a country')]
       },
       streetAddress: {
         label: 'Street Address',
+        required: true,
         validators: [validators.required('Please enter a street address')]
       },
       extendedAddress: {},
       locality: {
         label: 'Town/Suburb',
+        required: true,
         validators: [validators.required('Please enter a town/suburb')]
       },
       region: {
         label: 'State',
+        required: true,
         validators: [validators.required('Please enter a state')]
       },
       postCode: {
         label: 'Post Code',
+        required: true,
         validators: [validators.required('Please enter a post code')]
       }
     })


### PR DESCRIPTION
Currently, the address search and the normal address fields (in CreatePageForm) don't show required asterisks.

The fields are easy as we can just add `required: true`

The search not so much, as it has a custom label with the `Enter Manually` button you can click to opt out of searching. Placing `required: true` renders the asterisk on a new line and looks all messed up. This is obviously s9n, so we don't want to really add styles, so I came up with a workaround (hack), using the most barebones c11n component I could think of i.e. Section, which in this case will just render a `span` with the foreground color set to `danger`

Screenshot for added pressure to ✅.

![image](https://user-images.githubusercontent.com/1445686/60638226-dfc83600-9e60-11e9-8d1e-37dbe3f615e3.png)
