### PR TITLE
Guard against API issues w/ order of leaderboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.9.1",
+  "version": "3.10.0",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/components/leaderboard/index.js
+++ b/source/components/leaderboard/index.js
@@ -61,7 +61,7 @@ class Leaderboard extends Component {
     })
   }
 
-  handleData (data, excludeOffline, deserializeMethod) {
+  handleData (data, excludeOffline, deserializeMethod, limit) {
     const leaderboardData = data
       .map(deserializeMethod)
       .map(
@@ -72,7 +72,7 @@ class Leaderboard extends Component {
       )
       .map((item, index) => ({ ...item, position: index + 1 }))
 
-    return orderBy(leaderboardData, ['raised'], ['desc'])
+    return orderBy(leaderboardData, ['raised'], ['desc']).slice(0, limit)
   }
 
   fetchLeaderboard (q, refresh) {
@@ -111,7 +111,7 @@ class Leaderboard extends Component {
       excludePageIds: type === 'group' ? undefined : excludePageIds,
       group,
       groupID,
-      limit,
+      limit: limit + 5,
       maxAmount,
       minAmount,
       page,
@@ -132,7 +132,8 @@ class Leaderboard extends Component {
           data: this.handleData(
             data,
             excludeOffline,
-            deserializeMethod || deserializeLeaderboard
+            deserializeMethod || deserializeLeaderboard,
+            limit
           )
         })
       })

--- a/source/components/leaderboard/index.js
+++ b/source/components/leaderboard/index.js
@@ -62,23 +62,17 @@ class Leaderboard extends Component {
   }
 
   handleData (data, excludeOffline, deserializeMethod) {
-    const leaderboardData = data.map(deserializeMethod)
+    const leaderboardData = data
+      .map(deserializeMethod)
+      .map(
+        item =>
+          excludeOffline
+            ? { ...item, raised: item.raised - item.offline }
+            : item
+      )
+      .map((item, index) => ({ ...item, position: index + 1 }))
 
-    if (excludeOffline) {
-      return orderBy(
-        leaderboardData.map(item => ({
-          ...item,
-          raised: item.raised - item.offline
-        })),
-        ['raised'],
-        ['desc']
-      ).map((item, index) => ({
-        ...item,
-        position: index + 1
-      }))
-    }
-
-    return leaderboardData
+    return orderBy(leaderboardData, ['raised'], ['desc'])
   }
 
   fetchLeaderboard (q, refresh) {


### PR DESCRIPTION
1. Explicitly re-order the results
2. Fetch an extra 5 records, and then trim final result before returning