### PR TITLE
Fetch JG page by numeric slug

### DIFF
--- a/source/api/pages/__tests__/fetch-test.js
+++ b/source/api/pages/__tests__/fetch-test.js
@@ -160,6 +160,17 @@ describe('Fetch Pages', () => {
         })
       })
 
+      it('uses the correct url to fetch a page by slug if optional param is passed', done => {
+        fetchPage(123, true)
+        moxios.wait(() => {
+          const request = moxios.requests.mostRecent()
+          expect(request.url).to.equal(
+            'https://api.justgiving.com/v1/fundraising/pages/123'
+          )
+          done()
+        })
+      })
+
       it('uses an alternate url to fetch a page by id', done => {
         fetchPage('123')
         moxios.wait(() => {

--- a/source/api/pages/index.js
+++ b/source/api/pages/index.js
@@ -33,8 +33,8 @@ export const fetchPages = params =>
 /**
  * @function fetches a single page
  */
-export const fetchPage = page =>
-  isJustGiving() ? fetchJGPage(page) : fetchEDHPage(page)
+export const fetchPage = (...args) =>
+  isJustGiving() ? fetchJGPage(...args) : fetchEDHPage(...args)
 
 /**
  * @function fetches a page's donation count

--- a/source/api/pages/justgiving/index.js
+++ b/source/api/pages/justgiving/index.js
@@ -130,8 +130,8 @@ export const fetchPages = (params = required()) => {
   )
 }
 
-export const fetchPage = (page = required()) => {
-  const endpoint = isNaN(page) ? 'pages' : 'pagebyid'
+export const fetchPage = (page = required(), slug) => {
+  const endpoint = slug ? 'pages' : isNaN(page) ? 'pages' : 'pagebyid'
   return get(`/v1/fundraising/${endpoint}/${page}`)
 }
 


### PR DESCRIPTION
Until today I didn't realise (or consider really) that you could create a JG page with an entirely numeric slug. Turns out you can, which caused issues with the `fetchPage` method, so I've added an optional param to force fetching by slug even if the slug is a number.