### PR TITLE
Add option for a charity dropdown in create page form

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.10.1",
+  "version": "3.11.0",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/components/charity-select/Readme.md
+++ b/source/components/charity-select/Readme.md
@@ -1,0 +1,10 @@
+### Examples
+
+```
+<CharitySelect
+  campaign='au-6839'
+  inputProps={{
+    onChange: window.alert
+  }}
+/>
+```

--- a/source/components/charity-select/index.js
+++ b/source/components/charity-select/index.js
@@ -1,0 +1,63 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import { fetchCharities } from '../../api/charities'
+
+import InputSelect from 'constructicon/input-select'
+
+class CharitySelect extends Component {
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      results: [],
+      status: null
+    }
+  }
+
+  componentDidMount () {
+    const { campaign } = this.props
+
+    Promise.resolve()
+      .then(() => this.setState({ status: 'fetching' }))
+      .then(() => fetchCharities({ campaign }))
+      .then(results => results.map(this.deserializeCharity))
+      .then(results => this.setState({ results, status: 'fetched' }))
+      .catch(error => {
+        this.setState({ status: 'failed' })
+        return Promise.reject(error)
+      })
+  }
+
+  deserializeCharity (charity) {
+    return {
+      label: charity.name,
+      value: charity.id
+    }
+  }
+
+  render () {
+    const { inputProps } = this.props
+    const { results } = this.state
+
+    return (
+      <InputSelect
+        options={[{ label: 'Please select', value: '' }, ...results]}
+        {...inputProps}
+      />
+    )
+  }
+}
+
+CharitySelect.propTypes = {
+  /**
+   * Only show charities in this campaign
+   */
+  campaign: PropTypes.string,
+
+  /**
+   * The props to be passed to the input select component
+   */
+  inputProps: PropTypes.object
+}
+
+export default CharitySelect

--- a/source/components/create-page-form/Readme.md
+++ b/source/components/create-page-form/Readme.md
@@ -63,6 +63,17 @@ const fields = {
 />
 ```
 
+### With charity select
+
+```
+<CreatePageForm
+  campaignId='au-6839'
+  token='1234abcd'
+  includeCharitySearch='select'
+  onSuccess={(result) => alert(JSON.stringify(result))}
+/>
+```
+
 ### With address (EDH only)
 
 ```

--- a/source/components/create-page-form/index.js
+++ b/source/components/create-page-form/index.js
@@ -18,6 +18,7 @@ import countries from '../../utils/countries'
 
 import AddressSearch from '../address-search'
 import CharitySearch from '../charity-search'
+import CharitySelect from '../charity-select'
 import Form from 'constructicon/form'
 import Grid from 'constructicon/grid'
 import GridColumn from 'constructicon/grid-column'
@@ -207,11 +208,17 @@ class CreatePageForm extends Component {
                 />
               )
             case 'charityId':
-              return (
+              return field.type === 'search' ? (
                 <CharitySearch
                   key={field.name}
                   campaign={campaignId}
                   onChange={charity => field.onChange(charity.id)}
+                  inputProps={{ ...field, ...inputField }}
+                />
+              ) : (
+                <CharitySelect
+                  key={field.name}
+                  campaign={campaignId}
                   inputProps={{ ...field, ...inputField }}
                 />
               )
@@ -333,9 +340,9 @@ CreatePageForm.propTypes = {
   token: PropTypes.string.isRequired,
 
   /**
-   * Include a charity search field
+   * Include a charity search field - can be either "search" or "select" (defaults to search)
    */
-  includeCharitySearch: PropTypes.bool,
+  includeCharitySearch: PropTypes.oneOf([PropTypes.bool, 'search', 'select']),
 
   /**
    * Include phone in page creation
@@ -412,7 +419,10 @@ const form = props => {
     ...(props.includeCharitySearch && {
       charityId: {
         label: 'Charity',
-        type: 'search',
+        type:
+          typeof props.includeCharitySearch === 'string'
+            ? props.includeCharitySearch
+            : 'search',
         order: 2,
         required: true,
         validators: [validators.required('Please select your charity')]

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -89,6 +89,7 @@ module.exports = {
       components: () => [
         path.resolve(__dirname, 'source/components/address-search', 'index.js'),
         path.resolve(__dirname, 'source/components/charity-search', 'index.js'),
+        path.resolve(__dirname, 'source/components/charity-select', 'index.js'),
         path.resolve(
           __dirname,
           'source/components/create-page-form',


### PR DESCRIPTION
If a campaign only has a small handful of charities to select from, a charity search doesn't make sense as the user has to type to try and guess what one of the 5 or 6 charities are. In this case it makes more sense to render them in a dropdown instead.

* Added a `CharitySelect` component that takes a campaign and renders an `InputSelect` with charities within the campaign
* Allowed the existing `includeCharitySearch` prop to also be either `search` or `select`, and then render the select or search field depending on the selection, defaulting to `search` so it is completely backwards compatible.

NOTE: future change will be to site builder to allow you to make this a dropdown if it suits your campaign.