### PR TITLE
 Do not fetch additional pages for JG leaderboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.11.1",
+  "version": "3.11.2",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/components/leaderboard/index.js
+++ b/source/components/leaderboard/index.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import orderBy from 'lodash/orderBy'
 import PropTypes from 'prop-types'
 import numbro from 'numbro'
+import { isJustGiving } from '../../utils/client'
 
 import Filter from 'constructicon/filter'
 import Grid from 'constructicon/grid'
@@ -111,7 +112,7 @@ class Leaderboard extends Component {
       excludePageIds: type === 'group' ? undefined : excludePageIds,
       group,
       groupID,
-      limit: limit + 5,
+      limit: isJustGiving() ? limit : limit + 5,
       maxAmount,
       minAmount,
       page,


### PR DESCRIPTION
We added a change for EDH to fetch additional pages, sort, and then slice the results to the desired length. This was get around the bug with the leaderboard results sometimes being out of order.

The issue w/ JG is that it applies hard validation on what the `maxResults` param can be i.e. if you ask for 100 results, the leaderboard component will try and fetch 105, which returns a 400 validation error.