### PR TITLE
Add support for multiple JG events in leaderboards & totals

### DIFF
--- a/source/api/donation-totals/__tests__/totals-test.js
+++ b/source/api/donation-totals/__tests__/totals-test.js
@@ -73,7 +73,7 @@ describe('Fetch Donation Totals', () => {
       moxios.wait(() => {
         const request = moxios.requests.mostRecent()
         expect(request.url).to.equal(
-          'https://api.justgiving.com/v1/event/12345/leaderboard?currency=GBP'
+          'https://api.justgiving.com/v1/events/leaderboard?eventid=12345&currency=GBP'
         )
         done()
       })
@@ -84,7 +84,7 @@ describe('Fetch Donation Totals', () => {
       moxios.wait(() => {
         const request = moxios.requests.mostRecent()
         expect(request.url).to.equal(
-          'https://api.justgiving.com/v1/event/12345/leaderboard?currency=EUR'
+          'https://api.justgiving.com/v1/events/leaderboard?eventid=12345&currency=EUR'
         )
         done()
       })

--- a/source/api/donation-totals/justgiving/index.js
+++ b/source/api/donation-totals/justgiving/index.js
@@ -1,15 +1,28 @@
 import client from '../../../utils/client'
 import get from 'lodash/get'
 import { fetchCampaign } from '../../campaigns'
-import { getUID, required, dataSource } from '../../../utils/params'
+import {
+  getUID,
+  required,
+  dataSource,
+  paramsSerializer
+} from '../../../utils/params'
 import { currencyCode } from '../../../utils/currencies'
 
 export const fetchDonationTotals = (params = required()) => {
   switch (dataSource(params)) {
     case 'event':
-      return client.get(`v1/event/${getUID(params.event)}/leaderboard`, {
-        currency: currencyCode(params.country)
-      })
+      return client.get(
+        '/v1/events/leaderboard',
+        {
+          eventid: Array.isArray(params.event)
+            ? params.event.map(getUID)
+            : getUID(params.event),
+          currency: currencyCode(params.country)
+        },
+        {},
+        { paramsSerializer }
+      )
     case 'charity':
       // No API method supports total funds raised for a charity
       return required()

--- a/source/api/leaderboard/__tests__/fetch-test.js
+++ b/source/api/leaderboard/__tests__/fetch-test.js
@@ -150,7 +150,7 @@ describe('Fetch Leaderboards', () => {
       moxios.wait(function () {
         const request = moxios.requests.mostRecent()
         expect(request.url).to.equal(
-          'https://api.justgiving.com/v1/event/12345/leaderboard?currency=GBP'
+          'https://api.justgiving.com/v1/events/leaderboard?eventid=12345&currency=GBP'
         )
         done()
       })
@@ -161,7 +161,18 @@ describe('Fetch Leaderboards', () => {
       moxios.wait(function () {
         const request = moxios.requests.mostRecent()
         expect(request.url).to.equal(
-          'https://api.justgiving.com/v1/event/12345/leaderboard?currency=AUD'
+          'https://api.justgiving.com/v1/events/leaderboard?eventid=12345&currency=AUD'
+        )
+        done()
+      })
+    })
+
+    it('fetches pages for multiple events', done => {
+      fetchJGLeaderboard({ event: [12345, 54321] })
+      moxios.wait(function () {
+        const request = moxios.requests.mostRecent()
+        expect(request.url).to.equal(
+          'https://api.justgiving.com/v1/events/leaderboard?eventid=12345&eventid=54321&currency=GBP'
         )
         done()
       })
@@ -172,7 +183,7 @@ describe('Fetch Leaderboards', () => {
       moxios.wait(function () {
         const request = moxios.requests.mostRecent()
         expect(request.url).to.equal(
-          'https://api.justgiving.com/v1/event/12345/leaderboard?currency=GBP&maxResults=50'
+          'https://api.justgiving.com/v1/events/leaderboard?eventid=12345&currency=GBP&maxResults=50'
         )
         done()
       })

--- a/source/api/leaderboard/justgiving/index.js
+++ b/source/api/leaderboard/justgiving/index.js
@@ -1,5 +1,10 @@
 import { get, isStaging, servicesAPI } from '../../../utils/client'
-import { getUID, required, dataSource } from '../../../utils/params'
+import {
+  getUID,
+  required,
+  dataSource,
+  paramsSerializer
+} from '../../../utils/params'
 import { currencySymbol, currencyCode } from '../../../utils/currencies'
 
 /**
@@ -8,10 +13,18 @@ import { currencySymbol, currencyCode } from '../../../utils/currencies'
 export const fetchLeaderboard = (params = required()) => {
   switch (dataSource(params)) {
     case 'event':
-      return get(`/v1/event/${getUID(params.event)}/leaderboard`, {
-        currency: currencyCode(params.country),
-        maxResults: params.limit
-      }).then(response =>
+      return get(
+        '/v1/events/leaderboard',
+        {
+          eventid: Array.isArray(params.event)
+            ? params.event.map(getUID)
+            : getUID(params.event),
+          currency: currencyCode(params.country),
+          maxResults: params.limit
+        },
+        {},
+        { paramsSerializer }
+      ).then(response =>
         response.pages.map(page => ({
           ...page,
           raisedAmount: page.amount,

--- a/source/components/leaderboard/index.js
+++ b/source/components/leaderboard/index.js
@@ -235,6 +235,15 @@ Leaderboard.propTypes = {
   ]),
 
   /**
+   * The event uid to fetch pages for (JG only)
+   */
+  event: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.array
+  ]),
+
+  /**
    * Country code for API (JG only)
    */
   country: PropTypes.oneOf([

--- a/source/components/progress-bar/index.js
+++ b/source/components/progress-bar/index.js
@@ -161,6 +161,15 @@ ProgressBar.propTypes = {
   ]),
 
   /**
+   * The event uid to fetch totals for (JG only)
+   */
+  event: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.array
+  ]),
+
+  /**
    * Country code for API (JG only)
    */
   country: PropTypes.oneOf([

--- a/source/components/total-donations/index.js
+++ b/source/components/total-donations/index.js
@@ -104,6 +104,15 @@ TotalDonations.propTypes = {
   ]),
 
   /**
+   * The event uid to fetch totals for (JG only)
+   */
+  event: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.array
+  ]),
+
+  /**
    * The charity uid to fetch totals for
    */
   activity: PropTypes.oneOf([

--- a/source/components/total-funds-raised/index.js
+++ b/source/components/total-funds-raised/index.js
@@ -104,6 +104,15 @@ TotalFundsRaised.propTypes = {
   ]),
 
   /**
+   * The event uid to fetch totals for (JG only)
+   */
+  event: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.array
+  ]),
+
+  /**
    * The charity uid to fetch totals for
    */
   activity: PropTypes.oneOf([

--- a/source/utils/params/index.js
+++ b/source/utils/params/index.js
@@ -1,11 +1,13 @@
+import keys from 'lodash/keys'
+
 export const required = () => {
   throw new Error('Required parameter not supplied')
 }
 
 export const dataSource = ({ event, charity, campaign }) => {
   if (event) {
-    if (isNaN(event) && isNaN(event.uid)) {
-      throw new Error('Event parameter must be an ID')
+    if (isNaN(event) && isNaN(event.uid) && !Array.isArray(event)) {
+      throw new Error('Event parameter must be an ID or an array')
     }
 
     return 'event'
@@ -26,3 +28,19 @@ export const getUID = data => (typeof data === 'object' ? data.uid : data)
 
 export const getShortName = data =>
   typeof data === 'object' ? data.shortName : data
+
+export const paramsSerializer = params =>
+  keys(params)
+    .map(key => {
+      const value = params[key]
+
+      if (!value) return false
+
+      if (Array.isArray(value)) {
+        return value.map(val => [key, val].join('=')).join('&')
+      }
+
+      return [key, value].join('=')
+    })
+    .filter(Boolean)
+    .join('&')


### PR DESCRIPTION
Now that we have an API endpoint with support for multiple event IDs, why not use it!

e.g. `https://api.justgiving.com/v1/events/leaderboard?eventid=123&eventid=321`