### PR TITLE
Address search should use showMore option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.11.10",
+  "version": "3.11.11",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/components/address-search/index.js
+++ b/source/components/address-search/index.js
@@ -77,6 +77,7 @@ class AddressSearch extends Component {
             onChange={this.handleSelect}
             onSearch={this.handleQuery}
             results={results}
+            showMore
             status={status}
             validations={validations}
             value={value}


### PR DESCRIPTION
It is common for an address search to return more than 5 results, which means some results are currently hidden. This is especially true in the UK where they often search via post code, which can return more than 5 results.

![image](https://user-images.githubusercontent.com/1445686/66087609-6ce36e00-e5bb-11e9-9307-f4c6fa377984.png)
