### PR TITLE
Convert target cents

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.12.1",
+  "version": "3.13.0",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/pages/everydayhero/index.js
+++ b/source/api/pages/everydayhero/index.js
@@ -28,7 +28,8 @@ export const deserializePage = page => {
     raised: amountInCents / 100,
     slug: page.slug,
     story: page.story,
-    target: page.metrics ? page.metrics.fundraising.goal : page.target_cents,
+    target:
+      (page.metrics ? page.metrics.fundraising.goal : page.target_cents) / 100,
     teamPageId: page.team_page_id,
     teamRole: page.team_role,
     url: page.url,


### PR DESCRIPTION
Ever since https://github.com/everydayhero/supporticon/commit/b34fe2ccc6fa0e47de6fa0ca294d9952b09ca5a9 we've been deserialising `raised` amount in dollars rather than cents, but the `target` amount was left behind.

Interestingly, the [related leaderboard method](https://github.com/everydayhero/supporticon/blob/master/source/api/leaderboard/everydayhero/index.js#L56) was already normalising to dollars 🤷‍♂