### PR TITLE
Allow user to pass limit to fetchPages for JG

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/pages/__tests__/fetch-test.js
+++ b/source/api/pages/__tests__/fetch-test.js
@@ -37,6 +37,18 @@ describe('Fetch Pages', () => {
         })
       })
 
+      it('sets the limit on the request', done => {
+        fetchPages({ campaign_id: 'au-6839', allPages: true, limit: 50 })
+        moxios.wait(() => {
+          const request = moxios.requests.mostRecent()
+          expect(request.url).to.contain(
+            'https://everydayhero.com/api/v2/pages'
+          )
+          expect(request.url).to.contain('limit=50')
+          done()
+        })
+      })
+
       it('throws if no params are passed in', () => {
         const test = () => fetchPages()
         expect(test).to.throw
@@ -178,6 +190,18 @@ describe('Fetch Pages', () => {
           expect(request.url).to.equal(
             'https://api.justgiving.com/v1/fundraising/pagebyid/123'
           )
+          done()
+        })
+      })
+
+      it('fetches pages by event with the correct pageSize', done => {
+        fetchPages({ event: '123', allPages: true, limit: 50 })
+        moxios.wait(() => {
+          const request = moxios.requests.mostRecent()
+          expect(request.url).to.contain(
+            'https://api.justgiving.com/v1/event/123/pages'
+          )
+          expect(request.url).to.contain('pageSize=50')
           done()
         })
       })

--- a/source/api/pages/justgiving/index.js
+++ b/source/api/pages/justgiving/index.js
@@ -96,7 +96,9 @@ export const fetchPages = (params = required()) => {
   }
 
   if (allPages && event) {
-    return get(`/v1/event/${getUID(event)}/pages`).then(
+    const mappings = { limit: 'pageSize' }
+
+    return get(`/v1/event/${getUID(event)}/pages`, args, { mappings }).then(
       response => response.fundraisingPages
     )
   }


### PR DESCRIPTION
Passing in a `limit` to fetchPages already worked for EDH, but was not hooked up to work for EDH events. This change means you can now pass in limit to fetchPages, whether EDH or JG and get the expected number of results.

There will be a quick change in site builder to use this param, so they can use PageProgressTiles in higher ed (and other) sites that have more than the default 20 pages.