### PR TITLE
Small changes to supporticon after site builder review

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.16.0",
+  "version": "3.16.1",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/pages/justgiving/index.js
+++ b/source/api/pages/justgiving/index.js
@@ -30,7 +30,9 @@ export const deserializePage = page => {
   }
 
   return {
-    active: [page.status, page.pageStatus].indexOf('Active') > -1,
+    active:
+      (!page.status && !page.pageStatus) ||
+      [page.status, page.pageStatus].indexOf('Inactive') > -1,
     campaign: page.Subtext || page.eventId || page.EventId,
     campaignDate: jsonDate(page.eventDate) || page.EventDate,
     charity: page.charity || page.CharityId,

--- a/source/utils/params/index.js
+++ b/source/utils/params/index.js
@@ -4,8 +4,16 @@ export const required = () => {
   throw new Error('Required parameter not supplied')
 }
 
+const isEmpty = val => {
+  if (Array.isArray(val)) {
+    return val.length === 0
+  } else {
+    return !val
+  }
+}
+
 export const dataSource = ({ event, charity, campaign }) => {
-  if (event) {
+  if (!isEmpty(event)) {
     if (isNaN(event) && isNaN(event.uid) && !Array.isArray(event)) {
       throw new Error('Event parameter must be an ID or an array')
     }


### PR DESCRIPTION
1. Sometimes event is an empty array, and therefore it is incorrectly deciding that the dataSource is `event`, because an empty array is not falsy
2. There are components in site builder that filter out pages where `active` is false. Problem is the deserializer expects `page.status` or `page.pageStatus` to be set. So if neither of these are present on the object we are deserializing, we just need to assume the page is active.