### PR TITLE
Update handling of JG campaign and charity donation totals

### DIFF
--- a/source/api/donation-totals/__tests__/totals-test.js
+++ b/source/api/donation-totals/__tests__/totals-test.js
@@ -106,6 +106,17 @@ describe('Fetch Donation Totals', () => {
         done()
       })
     })
+
+    it('uses the correct url to fetch totals for a charity', done => {
+      fetchJGDonationTotals({ charity: 1234 })
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent()
+        expect(request.url).to.include(
+          'https://api.justgiving.com/donationsleaderboards/v1/totals?charityIds=1234'
+        )
+        done()
+      })
+    })
   })
 })
 

--- a/source/utils/params/index.js
+++ b/source/utils/params/index.js
@@ -20,10 +20,6 @@ export const dataSource = ({ event, charity, campaign }) => {
 
     return 'event'
   } else if (charity && !campaign) {
-    if (isNaN(charity) && isNaN(charity.uid)) {
-      throw new Error('Charity parameter must be an ID')
-    }
-
     return 'charity'
   } else if (campaign) {
     return 'campaign'


### PR DESCRIPTION
- Use `/donationsleaderboards/v1/totals` for one or more charities
- Continue to use `/campaigns/v2/campaign/:guid` for campaigns, but add support for multiple

**Note:** We still have to use the latter endpoint for campaigns over the first one because it lacks support for offline donations.