### PR TITLE
Remove query-string dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "moment": "^2.22.2",
     "numbro": "^1.11.0",
     "prop-types": "^15.5.8",
-    "query-string": "^6.8.3",
     "url-parse": "^1.4.3"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.18.0",
+  "version": "3.18.1",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/feeds/justgiving/index.js
+++ b/source/api/feeds/justgiving/index.js
@@ -1,4 +1,3 @@
-import qs from 'query-string'
 import { get, servicesAPI } from '../../../utils/client'
 import { getUID } from '../../../utils/params'
 import jsonDate from '../../../utils/jsonDate'
@@ -25,7 +24,7 @@ export const fetchDonationFeed = ({
   )
 }
 
-const mapValue = v => (Array.isArray(v) ? v.map(getUID) : getUID(v))
+const mapValue = v => (Array.isArray(v) ? v.map(getUID).join(',') : getUID(v))
 
 export const fetchDonations = ({ event, charity, campaign, page }) =>
   servicesAPI
@@ -35,8 +34,7 @@ export const fetchDonations = ({ event, charity, campaign, page }) =>
         charityId: mapValue(charity),
         eventId: mapValue(event),
         fundraisingPageId: mapValue(page)
-      },
-      paramsSerializer: params => qs.stringify(params, { arrayFormat: 'comma' })
+      }
     })
     .then(response => response.data)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7552,15 +7552,6 @@ query-string@^4.1.0:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
-query-string@^6.8.3:
-  version "6.8.3"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.8.3.tgz#fd9fb7ffb068b79062b43383685611ee47777d4b"
-  integrity sha512-llcxWccnyaWlODe7A9hRjkvdCKamEKTh+wH8ITdTc3OhchaqUZteiSCX/2ablWHVrkVIe04dntnaZJ7BdyW0lQ==
-  dependencies:
-    decode-uri-component "^0.2.0"
-    split-on-first "^1.0.0"
-    strict-uri-encode "^2.0.0"
-
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -8839,11 +8830,6 @@ spdy@^3.4.1:
     select-hose "^2.0.0"
     spdy-transport "^2.0.18"
 
-split-on-first@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
-  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
-
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -8951,11 +8937,6 @@ stream-shift@^1.0.0:
 strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
-
-strict-uri-encode@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
-  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-argv@^0.0.2:
   version "0.0.2"


### PR DESCRIPTION
`query-string` has a dependency on a package that breaks things in IE11, so we typically use `querystring` instead. I noticed supporticon was doing some things that weren't supported in `querystring`, such as handling array formats differently. So instead of using `querystring`, I used no external package, and just joined the array by comma in the `mapValue` function instead, which achieves the same result.