### PR TITLE
Add locale support for address form labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.18.1",
+  "version": "3.18.2",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/components/create-page-form/index.js
+++ b/source/components/create-page-form/index.js
@@ -15,6 +15,7 @@ import { isJustGiving } from '../../utils/client'
 import { renderInput, renderFormFields } from '../../utils/form'
 import withGroups from './with-groups'
 import countries from '../../utils/countries'
+import * as addressHelpers from '../../utils/address'
 
 import AddressSearch from '../address-search'
 import CharitySearch from '../charity-search'
@@ -443,17 +444,17 @@ const form = props => {
       },
       extendedAddress: {},
       locality: {
-        label: 'Town/Suburb',
+        label: addressHelpers.localityLabel(props.country),
         required: true,
         validators: [validators.required('Please enter a town/suburb')]
       },
       region: {
-        label: 'State',
+        label: addressHelpers.regionLabel(props.country),
         required: true,
         validators: [validators.required('Please enter a state')]
       },
       postCode: {
-        label: 'Post Code',
+        label: addressHelpers.postCodeLabel(props.country),
         required: true,
         validators: [validators.required('Please enter a post code')]
       }

--- a/source/utils/address/index.js
+++ b/source/utils/address/index.js
@@ -1,0 +1,31 @@
+export const localityLabel = country => {
+  switch (country) {
+    case 'au':
+      return 'Town/Suburb'
+    case 'uk':
+    case 'gb':
+      return 'Town'
+    default:
+      return 'City'
+  }
+}
+
+export const regionLabel = country => {
+  switch (country) {
+    case 'uk':
+    case 'gb':
+      return 'County'
+    default:
+      return 'State'
+  }
+}
+
+export const postCodeLabel = country => {
+  switch (country) {
+    case 'us':
+    case 'ca':
+      return 'Zip Code'
+    default:
+      return 'Postcode'
+  }
+}


### PR DESCRIPTION
### US:
<img width="703" alt="us" src="https://user-images.githubusercontent.com/729085/69921568-d6f69180-14de-11ea-9268-ba423a89e615.png">

### AU:
<img width="701" alt="au" src="https://user-images.githubusercontent.com/729085/69921569-d6f69180-14de-11ea-8588-cf10eeab3769.png">

### UK:
<img width="696" alt="uk" src="https://user-images.githubusercontent.com/729085/69921570-d6f69180-14de-11ea-9e1d-212fd0ac03b3.png">
