### PR TITLE
add image count

### DIFF
--- a/source/api/pages/everydayhero/index.js
+++ b/source/api/pages/everydayhero/index.js
@@ -27,7 +27,7 @@ export const deserializePage = page => {
       : page.fitness_activity_overview,
     fitnessGoal: page.fitness_goal,
     groups: page.page_groups,
-    hasUpdatedImage: page.meta.has_set_image,
+    hasUpdatedImage: page.meta && page.meta.has_set_image,
     id: page.id,
     image: page.image && page.image.large_image_url,
     name: page.name,

--- a/source/api/pages/everydayhero/index.js
+++ b/source/api/pages/everydayhero/index.js
@@ -27,6 +27,7 @@ export const deserializePage = page => {
       : page.fitness_activity_overview,
     fitnessGoal: page.fitness_goal,
     groups: page.page_groups,
+    hasUpdatedImage: page.meta.has_set_image,
     id: page.id,
     image: page.image && page.image.large_image_url,
     name: page.name,

--- a/source/api/pages/justgiving/index.js
+++ b/source/api/pages/justgiving/index.js
@@ -41,9 +41,9 @@ export const deserializePage = page => {
     donationUrl: [url, 'donate'].join('/'),
     expired: jsonDate(page.expiryDate) && moment(page.expiryDate).isBefore(),
     groups: null,
+    hasUpdatedImage: page.imageCount !== '1',
     id: page.pageId || page.Id,
     image: getImage(),
-    imageCount: page.imageCount,
     name:
       page.title ||
       page.pageTitle ||

--- a/source/api/pages/justgiving/index.js
+++ b/source/api/pages/justgiving/index.js
@@ -43,6 +43,7 @@ export const deserializePage = page => {
     groups: null,
     id: page.pageId || page.Id,
     image: getImage(),
+    imageCount: page.imageCount,
     name:
       page.title ||
       page.pageTitle ||


### PR DESCRIPTION
Add image count to deserializePage for more reliable method to detect if page has updated page image. If more than 1, then the image has been updated. Will be useful for awarding badges. In past we have tested this based on string of default photo. I am noticing that this is no longer constant between different pages with same event if in different campaigns. 

For example for Wateraid we have 3 campaigns. The default photo for Individual Campaign is https://images.staging.justgiving.com/image/d31968b0-ddd9-4973-b57d-423f1edf4a40.jpg?imagetype=frpphoto&trymigrate=true, while for the Schools campaign it is https://images.staging.justgiving.com/image/d4985270-3176-404a-8210-3f491cc92aeb.jpg?imagetype=frpphoto&trymigrate=true. As a result, it would be easier to just use the imageCount property supplied from the JG API response.