### PR TITLE
update JG fetch team to new endpoint

### DIFF
--- a/source/api/teams/justgiving/index.js
+++ b/source/api/teams/justgiving/index.js
@@ -2,12 +2,12 @@ import { get, put } from '../../../utils/client'
 import { required } from '../../../utils/params'
 
 export const deserializeTeam = team => ({
-  id: team.id,
-  leader: null,
+  id: team.teamGuid,
+  leader: team.captain.userGuid,
   name: team.name,
-  pages: team.teamMembers,
-  raised: team.raisedSoFar,
-  slug: team.teamShortName
+  pages: team.membership.members,
+  raised: team.donationSummary.totalAmount,
+  slug: team.shortName
 })
 
 export const fetchTeams = () => {
@@ -17,7 +17,7 @@ export const fetchTeams = () => {
 }
 
 export const fetchTeam = (id = required()) => {
-  return get(`v1/team/${id}`)
+  return get(`v1/teams/${id}/full`)
 }
 
 export const createTeam = ({

--- a/source/api/teams/readme.md
+++ b/source/api/teams/readme.md
@@ -67,12 +67,12 @@ fetchTeams({
 
 **Purpose**
 
-Fetch a team for an authenticated user.
+Fetch a specific team by id.
 
 **Params**
 
 - `id` (Integer) Team ID _required_
-- `token` (String) OAuth User Token _required_
+- `token` (String) OAuth User Token _required EDH only_
 
 **Returns**
 


### PR DESCRIPTION
The old endpoint seems to no longer work for fetching a team. 

For example:
https://api.staging.justgiving.com/campaigns/v1/team/03f55763-72b9-4654-b845-0187cb8b2318/
Does not return anything. Tried to use SupportIcon to fetch an individual team in Wateraid and was not getting a response. The JG api docs seem out of date as well. Touched base with Luis on what the endpoint is now and updating accordingly here.

Using new endpoint, the response properties have changed a bit, so needed to update the deserializer to account for this.

Here is quick video of testing in postman as well (the old endpoint and the new):
https://drive.google.com/file/d/10KD21SM62Bwv2eIpgnueaF9xh_hlAUoZ/view