### PR TITLE
Support for create/join team in JG

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "moment": "^2.22.2",
     "numbro": "^1.11.0",
     "prop-types": "^15.5.8",
+    "slugify": "^1.4.0",
     "url-parse": "^1.4.3"
   },
   "peerDependencies": {

--- a/source/api/pages/justgiving/index.js
+++ b/source/api/pages/justgiving/index.js
@@ -157,6 +157,7 @@ export const createPage = ({
   activityType,
   attribution,
   authType = 'Basic',
+  campaignId,
   campaignGuid,
   causeId,
   charityFunded,
@@ -186,7 +187,7 @@ export const createPage = ({
     {
       activityType,
       attribution,
-      campaignGuid,
+      campaignGuid: campaignGuid || campaignId,
       causeId,
       charityFunded,
       charityId,

--- a/source/api/teams/__tests__/create-team--test.js
+++ b/source/api/teams/__tests__/create-team--test.js
@@ -58,20 +58,24 @@ describe('Create a Team', () => {
       createTeam({
         token: '012345abcdef',
         name: 'My Team',
-        slug: 'my-team',
         story: 'Lorem ipsum',
-        target: 1000
+        target: 1000,
+        campaignId: 'abc123',
+        captainSlug: 'captain'
       })
 
       moxios.wait(() => {
         const request = moxios.requests.mostRecent()
         const data = JSON.parse(request.config.data)
 
-        expect(request.url).to.contain('https://api.justgiving.com/v1/team')
+        expect(request.url).to.contain('https://api.justgiving.com/v2/teams')
         expect(request.config.headers['Authorization']).to.eql(
-          'Basic 012345abcdef'
+          'Bearer 012345abcdef'
         )
-        expect(data.teamShortName).to.eql('my-team')
+        expect(data.name).to.eql('My Team')
+        expect(data.campaignGuid).to.eql('abc123')
+        expect(data.captainPageShortName).to.eql('captain')
+        expect(data.teamTarget).to.eql(1000)
         done()
       })
     })

--- a/source/api/teams/__tests__/fetch-team--test.js
+++ b/source/api/teams/__tests__/fetch-team--test.js
@@ -14,11 +14,11 @@ describe('Fetch Teams', () => {
   describe('Fetch EDH Teams', () => {
     describe('Fetch many teams', () => {
       it('uses the correct url to fetch teams', done => {
-        fetchTeams({ token: '123456' })
+        fetchTeams({ campaign: 'abc123' })
         moxios.wait(() => {
           const request = moxios.requests.mostRecent()
           expect(request.url).to.contain(
-            'https://everydayhero.com/api/v2/teams'
+            'https://everydayhero.com/api/v2/pages?type=team&campaign_id=abc123'
           )
           done()
         })
@@ -32,13 +32,12 @@ describe('Fetch Teams', () => {
 
     describe('Fetch a single team', () => {
       it('uses the correct url to fetch a single team', done => {
-        fetchTeam({ id: '1234', token: '123456' })
+        fetchTeam('1234')
         moxios.wait(() => {
           const request = moxios.requests.mostRecent()
           expect(request.url).to.contain(
-            'https://everydayhero.com/api/v2/teams'
+            'https://everydayhero.com/api/v2/pages/1234'
           )
-          expect(request.url).to.contain('1234')
           done()
         })
       })
@@ -62,9 +61,16 @@ describe('Fetch Teams', () => {
     })
 
     describe('Fetch many teams', () => {
-      it('throws unsupported error', () => {
-        const test = () => fetchTeams()
-        expect(test).to.throw
+      it('uses the correct url to fetch teams', done => {
+        fetchTeams({ campaign: 'abc123' })
+        moxios.wait(() => {
+          const request = moxios.requests.mostRecent()
+          expect(request.url).to.contain(
+            'https://api.justgiving.com/campaigns/v1/teams/search'
+          )
+          expect(request.url).to.contain('CampaignGuid=abc123')
+          done()
+        })
       })
     })
 
@@ -73,8 +79,9 @@ describe('Fetch Teams', () => {
         fetchTeam('my-team')
         moxios.wait(() => {
           const request = moxios.requests.mostRecent()
-          expect(request.url).to.contain('https://api.justgiving.com/v1/team')
-          expect(request.url).to.contain('my-team')
+          expect(request.url).to.contain(
+            'https://api.justgiving.com/campaigns/v1/teams/my-team/full'
+          )
           done()
         })
       })

--- a/source/api/teams/__tests__/join-team--test.js
+++ b/source/api/teams/__tests__/join-team--test.js
@@ -55,8 +55,8 @@ describe('Join a Team', () => {
 
     it('hits the JG api with the correct url and data', done => {
       joinTeam({
-        id: 'my-team',
-        page: 'my-page',
+        teamSlug: 'my-team',
+        pageSlug: 'my-page',
         token: '012345abcdef'
       })
 
@@ -65,10 +65,10 @@ describe('Join a Team', () => {
         const data = JSON.parse(request.config.data)
 
         expect(request.url).to.contain(
-          'https://api.justgiving.com/v1/team/join'
+          'https://api.justgiving.com/v2/teams/join/my-team'
         )
         expect(request.config.headers['Authorization']).to.eql(
-          'Basic 012345abcdef'
+          'Bearer 012345abcdef'
         )
         expect(data.pageShortName).to.eql('my-page')
         done()

--- a/source/api/teams/everydayhero/index.js
+++ b/source/api/teams/everydayhero/index.js
@@ -1,54 +1,41 @@
-import { get, post } from '../../../utils/client'
+import get from 'lodash/get'
+import * as client from '../../../utils/client'
+import { fetchPages } from '../../pages'
 import { required } from '../../../utils/params'
 
 export const deserializeTeam = team => ({
   id: team.id,
-  leader: team.leader_id,
+  leader: team.team_leader_page_uid,
   name: team.name,
-  pages: team.page_ids,
-  raised: null,
-  slug: null
+  owner: team.owner_uid,
+  pages: team.team_member_uids,
+  raised: get(team, 'amount.cents'),
+  slug: team.slug,
+  url: team.url
 })
 
-export const fetchTeams = ({ token = required() }) => {
-  return get(
-    'api/v2/teams',
-    {},
-    {},
-    {
-      headers: {
-        Authorization: `Bearer ${token}`
-      }
-    }
-  ).then(response => response.teams)
-}
+export const fetchTeams = args =>
+  fetchPages({ type: 'team', allPages: true, ...args })
 
-export const fetchTeam = ({ id = required(), token = required() }) => {
-  return get(
-    `api/v2/teams/${id}`,
-    {},
-    {},
-    {
-      headers: {
-        Authorization: `Bearer ${token}`
-      }
-    }
-  ).then(response => response.team)
+export const fetchTeam = (id = required()) => {
+  return client.get(`api/v2/pages/${id}`).then(response => response.page)
 }
 
 export const createTeam = ({ token = required(), page = required(), name }) => {
-  return post(
-    'api/v2/teams',
-    {
-      individual_page_id: page,
-      name
-    },
-    {
-      headers: {
-        Authorization: `Bearer ${token}`
+  return client
+    .post(
+      'api/v2/teams',
+      {
+        individual_page_id: page,
+        name
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${token}`
+        }
       }
-    }
-  ).then(response => response.page)
+    )
+    .then(response => response.page)
 }
 
 export const joinTeam = ({
@@ -56,15 +43,17 @@ export const joinTeam = ({
   page = required(),
   token = required()
 }) => {
-  return post(
-    `api/v2/teams/${id}/join-requests`,
-    {
-      individual_page_id: page
-    },
-    {
-      headers: {
-        Authorization: `Bearer ${token}`
+  return client
+    .post(
+      `api/v2/teams/${id}/join-requests`,
+      {
+        individual_page_id: page
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${token}`
+        }
       }
-    }
-  ).then(response => response.team)
+    )
+    .then(response => response.team)
 }

--- a/source/api/teams/everydayhero/index.js
+++ b/source/api/teams/everydayhero/index.js
@@ -22,19 +22,19 @@ export const fetchTeam = (id = required()) => {
 }
 
 export const createTeam = ({ token = required(), page = required(), name }) => {
+  const payload = {
+    individual_page_id: page,
+    name
+  }
+
+  const options = {
+    headers: {
+      Authorization: `Bearer ${token}`
+    }
+  }
+
   return client
-    .post(
-      'api/v2/teams',
-      {
-        individual_page_id: page,
-        name
-      },
-      {
-        headers: {
-          Authorization: `Bearer ${token}`
-        }
-      }
-    )
+    .post('api/v2/teams', payload, options)
     .then(response => response.page)
 }
 
@@ -43,17 +43,17 @@ export const joinTeam = ({
   page = required(),
   token = required()
 }) => {
+  const payload = {
+    individual_page_id: page
+  }
+
+  const options = {
+    headers: {
+      Authorization: `Bearer ${token}`
+    }
+  }
+
   return client
-    .post(
-      `api/v2/teams/${id}/join-requests`,
-      {
-        individual_page_id: page
-      },
-      {
-        headers: {
-          Authorization: `Bearer ${token}`
-        }
-      }
-    )
+    .post(`api/v2/teams/${id}/join-requests`, payload, options)
     .then(response => response.team)
 }

--- a/source/api/teams/index.js
+++ b/source/api/teams/index.js
@@ -19,9 +19,8 @@ import {
 export const deserializeTeam = team =>
   isJustGiving() ? deserializeJGTeam(team) : deserializeEDHTeam(team)
 
-export const fetchTeams = params => {
-  return isJustGiving() ? fetchJGTeams(params) : fetchEDHTeams(params)
-}
+export const fetchTeams = params =>
+  isJustGiving() ? fetchJGTeams(params) : fetchEDHTeams(params)
 
 export const fetchTeam = params =>
   isJustGiving() ? fetchJGTeam(params) : fetchEDHTeam(params)

--- a/source/api/teams/justgiving/index.js
+++ b/source/api/teams/justgiving/index.js
@@ -1,68 +1,110 @@
-import { get, put } from '../../../utils/client'
+import get from 'lodash/get'
+import slugify from 'slugify'
+import * as client from '../../../utils/client'
 import { required } from '../../../utils/params'
 
-export const deserializeTeam = team => ({
-  id: team.teamGuid,
-  leader: team.captain.userGuid,
-  name: team.name,
-  pages: team.membership.members,
-  raised: team.donationSummary.totalAmount,
-  slug: team.shortName
-})
+export const deserializeTeam = team => {
+  const subdomain = client.isStaging() ? 'www.staging' : 'www'
 
-export const fetchTeams = () => {
-  return Promise.reject(
-    new Error('This method is not supported for JustGiving')
-  )
+  return {
+    id: team.teamGuid,
+    leader: get(team, 'captain.firstName'),
+    name: team.name,
+    pages: team.numberOfSupporters,
+    raised: get(team, 'donationSummary.totalAmount'),
+    slug: team.shortName,
+    url: `https://${subdomain}.justgiving.com/team/${team.shortName}`
+  }
+}
+
+export const fetchTeams = (options = required()) => {
+  const { campaign = required(), limit = 100 } = options
+
+  const params = {
+    CampaignGuid: campaign,
+    Take: limit
+  }
+
+  return client
+    .get('campaigns/v1/teams/search', params)
+    .then(data => data.results)
 }
 
 export const fetchTeam = (id = required()) => {
-  return get(`v1/teams/${id}/full`)
+  return client.get(`/campaigns/v1/teams/${id}/full`)
 }
 
-export const createTeam = ({
-  authType = 'Basic',
-  name = required(),
-  slug = required(),
-  story = required(),
-  target = required(),
-  targetType = 'Fixed',
-  teamType = 'Open',
-  token = required()
-}) => {
-  return put(
-    'v1/team',
-    {
-      name,
-      story,
-      targetType,
-      teamShortName: slug,
-      teamTarget: target,
-      teamType
-    },
-    {
-      headers: {
-        Authorization: [authType, token].join(' ')
-      }
+export const createTeam = params => {
+  const {
+    authType = 'Bearer',
+    name = required(),
+    campaignId = required(),
+    story = required(),
+    captainSlug = required(),
+    coverPhotoId,
+    target = 1000,
+    targetType = 'Fixed',
+    targetCurrency = 'GBP',
+    teamType = 'Open',
+    token = required()
+  } = params
+
+  if (authType === 'Basic') {
+    throw new Error('Teams does not support basic authentication')
+  }
+
+  const payload = {
+    campaignGuid: campaignId,
+    captainPageShortName: captainSlug,
+    coverPhotoId,
+    name,
+    story,
+    targetCurrency,
+    targetType,
+    teamShortName: slugify(params.name),
+    teamTarget: target,
+    teamType
+  }
+
+  const options = {
+    headers: {
+      Authorization: `${authType} ${token}`
     }
-  )
+  }
+
+  return client
+    .put('/v2/teams', payload, options)
+    .then(
+      res =>
+        res.errorMessage ? Promise.reject(new Error(res.errorMessage)) : res
+    )
+    .then(res => fetchTeam(res.teamGuid))
 }
 
 export const joinTeam = ({
-  authType = 'Basic',
-  id = required(),
-  page = required(),
+  authType = 'Bearer',
+  pageSlug = required(),
+  teamSlug = required(),
   token = required()
 }) => {
-  return put(
-    `v1/team/join/${id}`,
-    {
-      pageShortName: page
-    },
-    {
-      headers: {
-        Authorization: [authType, token].join(' ')
-      }
+  if (authType === 'Basic') {
+    throw new Error('Teams does not support basic authentication')
+  }
+
+  const payload = {
+    pageShortName: pageSlug
+  }
+
+  const options = {
+    headers: {
+      Authorization: `${authType} ${token}`
     }
-  )
+  }
+
+  return client
+    .put(`/v2/teams/join/${teamSlug}`, payload, options)
+    .then(
+      res =>
+        res.errorMessage ? Promise.reject(new Error(res.errorMessage)) : res
+    )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8921,6 +8921,11 @@ slide@^1.1.3, slide@^1.1.5, slide@~1.1.3, slide@~1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
 
+slugify@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.4.0.tgz#c9557c653c54b0c7f7a8e786ef3431add676d2cb"
+  integrity sha512-FtLNsMGBSRB/0JOE2A0fxlqjI6fJsgHGS13iTuVT28kViI4JjUiNqp/vyis0ZXYcMnpR3fzGNkv+6vRlI2GwdQ==
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"


### PR DESCRIPTION
* Updated `createTeam` and `joinTeam` based off March for Water
* `createPage` wasn't handling the `campaignId` param that the `CreatePageForm` was passing in, meaning pages weren't being put in the campaign, which was causing issues with teams
* Refactor EDH `fetchTeams` and `fetchTeam` to do a public team page search/lookup, rather than just getting the current user's teams, as we never used the old implementation and it is all now consistent with the JG implementation
* Refactor the EDH teams a bit, just because I was having an issue where Prettier kept formatting it, but Standard didn't like it