### PR TITLE
JG fitness

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.23.0",
+  "version": "3.24.0",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/fitness-leaderboard/__tests__/fetch-test.js
+++ b/source/api/fitness-leaderboard/__tests__/fetch-test.js
@@ -1,6 +1,6 @@
 import moxios from 'moxios'
 import { fetchFitnessLeaderboard } from '..'
-import { instance } from '../../../utils/client'
+import { instance, updateClient } from '../../../utils/client'
 
 describe('Fetch Fitness Leaderboards', () => {
   beforeEach(() => {
@@ -11,108 +11,157 @@ describe('Fetch Fitness Leaderboards', () => {
     moxios.uninstall(instance)
   })
 
-  it('uses the correct url to fetch a leaderboard', done => {
-    fetchFitnessLeaderboard({ campaign_id: 'au-6839', group_value: 'group123' })
-    moxios.wait(() => {
-      const request = moxios.requests.mostRecent()
-      expect(request.url).to.contain(
-        'https://everydayhero.com/api/v2/search/fitness_activities_totals'
-      )
-      expect(request.url).to.contain('campaign_id=au-6839')
-      expect(request.url).to.contain('group_value=group123')
-      done()
+  describe('for EDH', () => {
+    it('uses the correct url to fetch a leaderboard', done => {
+      fetchFitnessLeaderboard({
+        campaign_id: 'au-6839',
+        group_value: 'group123'
+      })
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent()
+        expect(request.url).to.contain(
+          'https://everydayhero.com/api/v2/search/fitness_activities_totals'
+        )
+        expect(request.url).to.contain('campaign_id=au-6839')
+        expect(request.url).to.contain('group_value=group123')
+        done()
+      })
+    })
+
+    it('throws if no params are passed in', () => {
+      const test = () => fetchFitnessLeaderboard()
+      expect(test).to.throw
+    })
+
+    it('uses the correct url to fetch a campaign leaderboard', done => {
+      fetchFitnessLeaderboard({ campaign: 'au-6839' })
+      moxios.wait(function () {
+        const request = moxios.requests.mostRecent()
+        expect(request.url).to.contain(
+          'https://everydayhero.com/api/v2/search/fitness_activities_totals'
+        )
+        expect(request.url).to.contain('campaign_id=au-6839')
+        done()
+      })
+    })
+
+    it('uses the correct url to fetch a leaderboard for multiple campaigns', done => {
+      fetchFitnessLeaderboard({ campaign: ['au-6839', 'au-6840'] })
+      moxios.wait(function () {
+        const request = moxios.requests.mostRecent()
+        expect(request.url).to.contain(
+          'https://everydayhero.com/api/v2/search/fitness_activities_totals'
+        )
+        expect(request.url).to.contain('campaign_id[]=au-6839')
+        expect(request.url).to.contain('campaign_id[]=au-6840')
+        done()
+      })
+    })
+
+    it('uses the correct url to fetch a charity leaderboard', done => {
+      fetchFitnessLeaderboard({ charity: 'au-28' })
+      moxios.wait(function () {
+        const request = moxios.requests.mostRecent()
+        expect(request.url).to.contain(
+          'https://everydayhero.com/api/v2/search/fitness_activities_totals'
+        )
+        expect(request.url).to.contain('charity_id=au-28')
+        done()
+      })
+    })
+
+    it('uses the correct url to fetch a leaderboard for multiple campaigns', done => {
+      fetchFitnessLeaderboard({ charity: ['au-28', 'au-29'] })
+      moxios.wait(function () {
+        const request = moxios.requests.mostRecent()
+        expect(request.url).to.contain(
+          'https://everydayhero.com/api/v2/search/fitness_activities_totals'
+        )
+        expect(request.url).to.contain('charity_id[]=au-28')
+        expect(request.url).to.contain('charity_id[]=au-29')
+        done()
+      })
+    })
+
+    it('correctly transforms page type params', done => {
+      fetchFitnessLeaderboard({ type: 'team' })
+      moxios.wait(function () {
+        const request = moxios.requests.mostRecent()
+        expect(request.url).to.contain(
+          'https://everydayhero.com/api/v2/search/fitness_activities_totals'
+        )
+        expect(request.url).to.contain('group_by=teams')
+        done()
+      })
+    })
+
+    it('correctly transforms activity type params', done => {
+      fetchFitnessLeaderboard({ activity: 'run' })
+      moxios.wait(function () {
+        const request = moxios.requests.mostRecent()
+        expect(request.url).to.contain(
+          'https://everydayhero.com/api/v2/search/fitness_activities_totals'
+        )
+        expect(request.url).to.contain('type=run')
+        done()
+      })
+    })
+
+    it('fetches leaderboards based on a group', done => {
+      fetchFitnessLeaderboard({ type: 'group', groupID: 99 })
+      moxios.wait(function () {
+        const request = moxios.requests.mostRecent()
+        expect(request.url).to.contain(
+          'https://everydayhero.com/api/v2/search/fitness_activities_totals'
+        )
+        expect(request.url).to.contain('group_by=groups')
+        expect(request.url).to.contain('group_id=99')
+        done()
+      })
     })
   })
 
-  it('throws if no params are passed in', () => {
-    const test = () => fetchFitnessLeaderboard()
-    expect(test).to.throw
-  })
-
-  it('uses the correct url to fetch a campaign leaderboard', done => {
-    fetchFitnessLeaderboard({ campaign: 'au-6839' })
-    moxios.wait(function () {
-      const request = moxios.requests.mostRecent()
-      expect(request.url).to.contain(
-        'https://everydayhero.com/api/v2/search/fitness_activities_totals'
-      )
-      expect(request.url).to.contain('campaign_id=au-6839')
-      done()
+  describe('for JG', () => {
+    beforeEach(() => {
+      updateClient({
+        baseURL: 'https://api.justgiving.com',
+        headers: { 'x-api-key': 'abcd1234' }
+      })
+      moxios.install(instance)
     })
-  })
 
-  it('uses the correct url to fetch a leaderboard for multiple campaigns', done => {
-    fetchFitnessLeaderboard({ campaign: ['au-6839', 'au-6840'] })
-    moxios.wait(function () {
-      const request = moxios.requests.mostRecent()
-      expect(request.url).to.contain(
-        'https://everydayhero.com/api/v2/search/fitness_activities_totals'
-      )
-      expect(request.url).to.contain('campaign_id[]=au-6839')
-      expect(request.url).to.contain('campaign_id[]=au-6840')
-      done()
+    afterEach(() => {
+      updateClient({ baseURL: 'https://everydayhero.com' })
+      moxios.uninstall(instance)
     })
-  })
 
-  it('uses the correct url to fetch a charity leaderboard', done => {
-    fetchFitnessLeaderboard({ charity: 'au-28' })
-    moxios.wait(function () {
-      const request = moxios.requests.mostRecent()
-      expect(request.url).to.contain(
-        'https://everydayhero.com/api/v2/search/fitness_activities_totals'
-      )
-      expect(request.url).to.contain('charity_id=au-28')
-      done()
+    it('throws if no params are passed in', () => {
+      const test = () => fetchFitnessLeaderboard()
+      expect(test).to.throw
     })
-  })
 
-  it('uses the correct url to fetch a leaderboard for multiple campaigns', done => {
-    fetchFitnessLeaderboard({ charity: ['au-28', 'au-29'] })
-    moxios.wait(function () {
-      const request = moxios.requests.mostRecent()
-      expect(request.url).to.contain(
-        'https://everydayhero.com/api/v2/search/fitness_activities_totals'
-      )
-      expect(request.url).to.contain('charity_id[]=au-28')
-      expect(request.url).to.contain('charity_id[]=au-29')
-      done()
+    it('uses the correct url to fetch a leaderboard', done => {
+      fetchFitnessLeaderboard({ campaign: '12345' })
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent()
+        expect(request.url).to.contain(
+          'https://api.justgiving.com/v1/fitness/campaign'
+        )
+        expect(request.url).to.contain('campaignGuid=12345')
+        done()
+      })
     })
-  })
 
-  it('correctly transforms page type params', done => {
-    fetchFitnessLeaderboard({ type: 'team' })
-    moxios.wait(function () {
-      const request = moxios.requests.mostRecent()
-      expect(request.url).to.contain(
-        'https://everydayhero.com/api/v2/search/fitness_activities_totals'
-      )
-      expect(request.url).to.contain('group_by=teams')
-      done()
-    })
-  })
-
-  it('correctly transforms activity type params', done => {
-    fetchFitnessLeaderboard({ activity: 'run' })
-    moxios.wait(function () {
-      const request = moxios.requests.mostRecent()
-      expect(request.url).to.contain(
-        'https://everydayhero.com/api/v2/search/fitness_activities_totals'
-      )
-      expect(request.url).to.contain('type=run')
-      done()
-    })
-  })
-
-  it('fetches leaderboards based on a group', done => {
-    fetchFitnessLeaderboard({ type: 'group', groupID: 99 })
-    moxios.wait(function () {
-      const request = moxios.requests.mostRecent()
-      expect(request.url).to.contain(
-        'https://everydayhero.com/api/v2/search/fitness_activities_totals'
-      )
-      expect(request.url).to.contain('group_by=groups')
-      expect(request.url).to.contain('group_id=99')
-      done()
+    it('uses the correct url to fetch a leaderboard for multiple campaigns', done => {
+      fetchFitnessLeaderboard({ campaign: ['12345', '98765'] })
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent()
+        expect(request.url).to.contain(
+          'https://api.justgiving.com/v1/fitness/campaign'
+        )
+        expect(request.url).to.contain('campaignGuid=12345&campaignGuid=98765')
+        done()
+      })
     })
   })
 })

--- a/source/api/fitness-leaderboard/everydayhero/index.js
+++ b/source/api/fitness-leaderboard/everydayhero/index.js
@@ -1,0 +1,82 @@
+import { get } from '../../../utils/client'
+import { required } from '../../../utils/params'
+
+export const c = {
+  ENDPOINT: 'api/v2/search/fitness_activities_totals'
+}
+
+/**
+ * @function fetches supporter pages ranked by fitness activities
+ */
+export const fetchFitnessLeaderboard = (params = required()) => {
+  const transforms = {
+    type: val =>
+      val === 'team' ? 'teams' : val === 'group' ? 'groups' : 'individuals',
+
+    sortBy: val => {
+      switch (val) {
+        case 'calories':
+          return 'calories'
+        case 'duration':
+          return 'duration_in_seconds'
+        case 'elevation':
+          return 'elevation_in_meters'
+        default:
+          return 'distance_in_meters'
+      }
+    }
+  }
+
+  const mappings = {
+    activity: 'type',
+    groupID: 'group_id',
+    type: 'group_by',
+    sortBy: 'sort_by'
+  }
+
+  return get(c.ENDPOINT, params, { mappings, transforms }).then(
+    response => response.results
+  )
+}
+
+/**
+ * @function a default deserializer for leaderboard pages
+ */
+export const deserializeFitnessLeaderboard = (result, index) => {
+  if (result.page) {
+    return deserializePage(result.page, result, index)
+  } else if (result.team) {
+    return deserializePage(result.team, result, index)
+  } else if (result.group) {
+    return deserializeGroup(result, index)
+  }
+}
+
+const deserializePage = (item, result, index) => ({
+  position: index + 1,
+  id: item.id,
+  name: item.name,
+  charity: item.charity_name,
+  charityLogo: item.charity_logo_url,
+  url: item.url,
+  donationUrl: item.donation_url,
+  image: item.image.medium_image_url,
+  raised: item.amount.cents,
+  groups: item.group_values,
+  distance: result.distance_in_meters,
+  elevation: result.elevation_in_meters,
+  calories: result.calories,
+  duration: result.duration_in_seconds
+})
+
+const deserializeGroup = (item, index) => ({
+  position: index + 1,
+  count: item.count,
+  id: item.group.id,
+  name: item.group.value,
+  raised: item.amount_cents / 100,
+  distance: item.distance_in_meters,
+  elevation: item.elevation_in_meters,
+  calories: item.calories,
+  duration: item.duration_in_seconds
+})

--- a/source/api/fitness-leaderboard/index.js
+++ b/source/api/fitness-leaderboard/index.js
@@ -8,7 +8,7 @@ import {
 import {
   deserializeFitnessLeaderboard as deserializeJGFitnessLeaderboard,
   fetchFitnessLeaderboard as fetchJGFitnessLeaderboard
-} from './everydayhero'
+} from './justgiving'
 
 /**
  * @function fetches supporter pages ranked by fitness activities

--- a/source/api/fitness-leaderboard/index.js
+++ b/source/api/fitness-leaderboard/index.js
@@ -1,86 +1,27 @@
-import { get, isJustGiving } from '../../utils/client'
-import { required } from '../../utils/params'
+import { isJustGiving } from '../../utils/client'
 
-export const c = {
-  ENDPOINT: 'api/v2/search/fitness_activities_totals'
-}
+import {
+  deserializeFitnessLeaderboard as deserializeEDHFitnessLeaderboard,
+  fetchFitnessLeaderboard as fetchEDHFitnessLeaderboard
+} from './everydayhero'
+
+import {
+  deserializeFitnessLeaderboard as deserializeJGFitnessLeaderboard,
+  fetchFitnessLeaderboard as fetchJGFitnessLeaderboard
+} from './everydayhero'
 
 /**
  * @function fetches supporter pages ranked by fitness activities
  */
-export const fetchFitnessLeaderboard = (params = required()) => {
-  if (isJustGiving()) {
-    return Promise.reject('This method is not supported for JustGiving')
-  }
-
-  const transforms = {
-    type: val =>
-      val === 'team' ? 'teams' : val === 'group' ? 'groups' : 'individuals',
-
-    sortBy: val => {
-      switch (val) {
-        case 'calories':
-          return 'calories'
-        case 'duration':
-          return 'duration_in_seconds'
-        case 'elevation':
-          return 'elevation_in_meters'
-        default:
-          return 'distance_in_meters'
-      }
-    }
-  }
-
-  const mappings = {
-    activity: 'type',
-    groupID: 'group_id',
-    type: 'group_by',
-    sortBy: 'sort_by'
-  }
-
-  return get(c.ENDPOINT, params, { mappings, transforms }).then(
-    response => response.results
-  )
-}
+export const fetchFitnessLeaderboard = params =>
+  isJustGiving()
+    ? fetchJGFitnessLeaderboard(params)
+    : fetchEDHFitnessLeaderboard(params)
 
 /**
  * @function a default deserializer for leaderboard pages
  */
-export const deserializeFitnessLeaderboard = (result, index) => {
-  if (result.page) {
-    return deserializePage(result.page, result, index)
-  } else if (result.team) {
-    return deserializePage(result.team, result, index)
-  } else if (result.group) {
-    return deserializeGroup(result, index)
-  }
-}
-
-const deserializePage = (item, result, index) => ({
-  position: index + 1,
-  id: item.id,
-  name: item.name,
-  charity: item.charity_name,
-  charityLogo: item.charity_logo_url,
-  url: item.url,
-  donationUrl: item.donation_url,
-  image: item.image.medium_image_url,
-  raised: item.amount.cents,
-  groups: item.group_values,
-  distance: result.distance_in_meters,
-  elevation: result.elevation_in_meters,
-  calories: result.calories,
-  duration: result.duration_in_seconds
-})
-
-const deserializeGroup = (item, index) => ({
-  position: index + 1,
-  count: item.count,
-  id: item.group.id,
-  name: item.group.value,
-  raised: item.amount_cents / 100,
-  distance: item.distance_in_meters,
-  elevation: item.elevation_in_meters,
-  calories: item.calories,
-  duration: item.duration_in_seconds
-})
+export const deserializeFitnessLeaderboard = (result, index) =>
+  isJustGiving()
+    ? deserializeJGFitnessLeaderboard(result, index)
+    : deserializeEDHFitnessLeaderboard(result, index)

--- a/source/api/fitness-leaderboard/justgiving/index.js
+++ b/source/api/fitness-leaderboard/justgiving/index.js
@@ -1,11 +1,35 @@
+import get from 'lodash/get'
+import * as client from '../../../utils/client'
+import { paramsSerializer, required } from '../../../utils/params'
+
 export const fetchFitnessLeaderboard = (params = required()) => {
-  return Promise.reject(
-    new Error('This method is not supported for JustGiving')
-  )
+  const { campaign = required(), type } = params
+
+  const query = {
+    campaignGuid: campaign
+  }
+
+  return client
+    .get('/v1/fitness/campaign', query, {}, { paramsSerializer })
+    .then(result => (type === 'team' ? result.teams : result.pages))
+    .then(items => items.filter(item => item.Details))
 }
 
-export const deserializeFitnessLeaderboard = (result, index) => {
-  return Promise.reject(
-    new Error('This method is not supported for JustGiving')
-  )
+export const deserializeFitnessLeaderboard = (item, index) => {
+  const subdomain = client.isStaging() ? 'www.staging' : 'www'
+
+  return {
+    position: index + 1,
+    id: item.ID,
+    name: get(item, 'Details.Name'),
+    url: `https://${subdomain}.justgiving.com/fundraising/${get(
+      item,
+      'Details.Url'
+    )}`,
+    image: `https://images${subdomain.replace(
+      'www',
+      ''
+    )}.jg-cdn.com/image/${get(item, 'Details.ImageId')}`,
+    distance: item.TotalValue
+  }
 }

--- a/source/api/fitness-leaderboard/justgiving/index.js
+++ b/source/api/fitness-leaderboard/justgiving/index.js
@@ -1,0 +1,11 @@
+export const fetchFitnessLeaderboard = (params = required()) => {
+  return Promise.reject(
+    new Error('This method is not supported for JustGiving')
+  )
+}
+
+export const deserializeFitnessLeaderboard = (result, index) => {
+  return Promise.reject(
+    new Error('This method is not supported for JustGiving')
+  )
+}

--- a/source/api/fitness-totals/__tests__/mocks/index.js
+++ b/source/api/fitness-totals/__tests__/mocks/index.js
@@ -15,6 +15,15 @@ export const singleCampaign = {
   }
 }
 
+export const singleJGCampaign = {
+  status: 200,
+  response: {
+    totalAmount: 100,
+    totalAmountElevation: 50,
+    totalAmountTaken: 100
+  }
+}
+
 export const multipleCampaigns = {
   status: 200,
   response: {

--- a/source/api/fitness-totals/everydayhero/index.js
+++ b/source/api/fitness-totals/everydayhero/index.js
@@ -1,0 +1,68 @@
+import { required } from '../../../utils/params'
+import pick from 'lodash/pick'
+import isEmpty from 'lodash/isEmpty'
+import fitnessTypes from '../consts/fitness-types'
+
+import { fetchCampaign, fetchCampaigns } from '../../campaigns'
+
+export const fetchFitnessSummary = (campaign = required(), types) =>
+  Array.isArray(campaign)
+    ? fetchCampaigns({ ids: campaign })
+      .then(results => results.map(result => deserializeOverview(result)))
+      .then(results => combineMultipleCampaigns(results))
+      .then(results => (types ? filterTypes(results, types) : results))
+      .catch(err => console.log(err))
+    : fetchCampaign(campaign)
+      .then(result => deserializeOverview(result))
+      .then(results => (types ? filterTypes(results, types) : results))
+      .catch(err => console.log(err))
+
+export const fetchFitnessTotals = (campaign = required(), types) =>
+  fetchFitnessSummary(campaign, types)
+    .then(summary =>
+      Object.keys(summary).reduce(
+        (result, item, i) => ({
+          duration: result.duration + summary[item].duration,
+          calories: result.calories + summary[item].calories,
+          distance: result.distance + summary[item].distance
+        }),
+        { duration: 0, calories: 0, distance: 0 }
+      )
+    )
+    .catch(err => console.log(err))
+
+const deserializeOverview = ({ fitness_activity_overview: overview }) =>
+  fitnessTypes.reduce((result, fitnessType, i) => {
+    const key = overview[fitnessType] || {}
+    return {
+      ...result,
+      [fitnessType]: {
+        duration: key.duration_in_seconds || 0,
+        calories: key.calories || 0,
+        distance: key.distance_in_meters || 0
+      }
+    }
+  }, {})
+
+const combineMultipleCampaigns = campaigns =>
+  fitnessTypes.reduce((result, fitnessType, i) => {
+    return {
+      ...result,
+      [fitnessType]: {
+        duration: addValuesFromAllCampaigns(campaigns, fitnessType, 'duration'),
+        calories: addValuesFromAllCampaigns(campaigns, fitnessType, 'calories'),
+        distance: addValuesFromAllCampaigns(campaigns, fitnessType, 'distance')
+      }
+    }
+  }, {})
+
+const addValuesFromAllCampaigns = (campaigns, fitnessType, key) =>
+  campaigns.reduce(
+    (result, campaign, i) => result + campaign[fitnessType][key],
+    0
+  )
+
+const filterTypes = (results, types) => {
+  const filtered = pick(results, types)
+  return !isEmpty(filtered) ? filtered : results
+}

--- a/source/api/fitness-totals/everydayhero/index.js
+++ b/source/api/fitness-totals/everydayhero/index.js
@@ -63,6 +63,7 @@ const addValuesFromAllCampaigns = (campaigns, fitnessType, key) =>
   )
 
 const filterTypes = (results, types) => {
-  const filtered = pick(results, types)
+  const typesArray = typeof types === 'string' ? [types] : types
+  const filtered = pick(results, typesArray)
   return !isEmpty(filtered) ? filtered : results
 }

--- a/source/api/fitness-totals/index.js
+++ b/source/api/fitness-totals/index.js
@@ -1,74 +1,21 @@
 import { isJustGiving } from '../../utils/client'
-import { required } from '../../utils/params'
-import pick from 'lodash/pick'
-import isEmpty from 'lodash/isEmpty'
-import fitnessTypes from './consts/fitness-types'
 
-import { fetchCampaign, fetchCampaigns } from '../campaigns'
+import {
+  fetchFitnessSummary as fetchEDHFitnessSummary,
+  fetchFitnessTotals as fetchEDHFitnessTotals
+} from './everydayhero'
 
-export const fetchFitnessSummary = (campaign = required(), types) => {
-  if (isJustGiving()) {
-    return Promise.reject('This method is not supported for JustGiving')
-  } else {
-    return Array.isArray(campaign)
-      ? fetchCampaigns({ ids: campaign })
-        .then(results => results.map(result => deserializeOverview(result)))
-        .then(results => combineMultipleCampaigns(results))
-        .then(results => (types ? filterTypes(results, types) : results))
-        .catch(err => console.log(err))
-      : fetchCampaign(campaign)
-        .then(result => deserializeOverview(result))
-        .then(results => (types ? filterTypes(results, types) : results))
-        .catch(err => console.log(err))
-  }
-}
+import {
+  fetchFitnessSummary as fetchJGFitnessSummary,
+  fetchFitnessTotals as fetchJGFitnessTotals
+} from './justgiving'
 
-export const fetchFitnessTotals = (campaign = required(), types) =>
-  fetchFitnessSummary(campaign, types)
-    .then(summary =>
-      Object.keys(summary).reduce(
-        (result, item, i) => ({
-          duration: result.duration + summary[item].duration,
-          calories: result.calories + summary[item].calories,
-          distance: result.distance + summary[item].distance
-        }),
-        { duration: 0, calories: 0, distance: 0 }
-      )
-    )
-    .catch(err => console.log(err))
+export const fetchFitnessSummary = (campaign, types) =>
+  isJustGiving()
+    ? fetchJGFitnessSummary(campaign, types)
+    : fetchEDHFitnessSummary(campaign, types)
 
-const deserializeOverview = ({ fitness_activity_overview: overview }) =>
-  fitnessTypes.reduce((result, fitnessType, i) => {
-    const key = overview[fitnessType] || {}
-    return {
-      ...result,
-      [fitnessType]: {
-        duration: key.duration_in_seconds || 0,
-        calories: key.calories || 0,
-        distance: key.distance_in_meters || 0
-      }
-    }
-  }, {})
-
-const combineMultipleCampaigns = campaigns =>
-  fitnessTypes.reduce((result, fitnessType, i) => {
-    return {
-      ...result,
-      [fitnessType]: {
-        duration: addValuesFromAllCampaigns(campaigns, fitnessType, 'duration'),
-        calories: addValuesFromAllCampaigns(campaigns, fitnessType, 'calories'),
-        distance: addValuesFromAllCampaigns(campaigns, fitnessType, 'distance')
-      }
-    }
-  }, {})
-
-const addValuesFromAllCampaigns = (campaigns, fitnessType, key) =>
-  campaigns.reduce(
-    (result, campaign, i) => result + campaign[fitnessType][key],
-    0
-  )
-
-const filterTypes = (results, types) => {
-  const filtered = pick(results, types)
-  return !isEmpty(filtered) ? filtered : results
-}
+export const fetchFitnessTotals = (campaign, types) =>
+  isJustGiving()
+    ? fetchJGFitnessTotals(campaign, types)
+    : fetchEDHFitnessTotals(campaign, types)

--- a/source/api/fitness-totals/justgiving/index.js
+++ b/source/api/fitness-totals/justgiving/index.js
@@ -1,0 +1,11 @@
+import { get } from '../../../utils/client'
+import { required } from '../../../utils/params'
+
+export const fetchFitnessSummary = (campaign = required(), types) => {
+  return Promise.reject(
+    new Error('This method is not supported for JustGiving')
+  )
+}
+
+export const fetchFitnessTotals = (campaign = required()) =>
+  get(`/v1/fitness/campaign/${campaign}`)

--- a/source/api/fitness-totals/justgiving/index.js
+++ b/source/api/fitness-totals/justgiving/index.js
@@ -1,11 +1,18 @@
-import { get } from '../../../utils/client'
-import { required } from '../../../utils/params'
+import * as client from '../../../utils/client'
+import { paramsSerializer, required } from '../../../utils/params'
 
-export const fetchFitnessSummary = (campaign = required(), types) => {
-  return Promise.reject(
-    new Error('This method is not supported for JustGiving')
-  )
+export const fetchFitnessSummary = (campaign = required(), types) =>
+  Promise.reject(new Error('This method is not supported for JustGiving'))
+
+export const fetchFitnessTotals = (campaign = required()) => {
+  const query = {
+    campaignGuid: campaign
+  }
+
+  return client
+    .get('/v1/fitness/campaign', query, {}, { paramsSerializer })
+    .then(result => ({
+      distance: result.totalAmount,
+      elevation: result.totalAmountElevation
+    }))
 }
-
-export const fetchFitnessTotals = (campaign = required()) =>
-  get(`/v1/fitness/campaign/${campaign}`)

--- a/source/components/total-distance/index.js
+++ b/source/components/total-distance/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import numbro from 'numbro'
-import { fetchCampaign, fetchCampaigns } from '../../api/campaigns'
+import { fetchFitnessTotals } from '../../api/fitness-totals'
 
 import Icon from 'constructicon/icon'
 import Loading from 'constructicon/loading'
@@ -26,69 +26,16 @@ class TotalDistance extends Component {
   }
 
   fetchData () {
-    const { campaign } = this.props
+    const { activity, campaign } = this.props
 
-    if (Array.isArray(campaign)) {
-      fetchCampaigns({ ids: campaign })
-        .then(data => {
-          let total = 0
-          data.map(campaign => {
-            total += this.calculateTotal(campaign)
-          })
-
-          this.setState({
-            status: 'fetched',
-            data: total
-          })
-        })
-        .catch(error => {
-          this.setState({ status: 'failed' })
-          return Promise.reject(error)
-        })
-    } else {
-      fetchCampaign(campaign)
-        .then(data => {
-          this.setState({
-            status: 'fetched',
-            data: this.calculateTotal(data)
-          })
-        })
-        .catch(error => {
-          this.setState({ status: 'failed' })
-          return Promise.reject(error)
-        })
-    }
-  }
-
-  getDistanceForActivityType (overview, type) {
-    const metrics = overview[type]
-    return metrics ? metrics.distance_in_meters : 0
-  }
-
-  calculateTotal (data) {
-    const { activity } = this.props
-    switch (typeof activity) {
-      case 'string':
-        return this.getDistanceForActivityType(
-          data.fitness_activity_overview,
-          activity
-        )
-      case 'object':
-        return activity.reduce(
-          (total, type) =>
-            (total += this.getDistanceForActivityType(
-              data.fitness_activity_overview,
-              type
-            )),
-          0
-        )
-      default:
-        return Object.keys(data.fitness_activity_overview).reduce(
-          (total, type) =>
-            (total += data.fitness_activity_overview[type].distance_in_meters),
-          0
-        )
-    }
+    fetchFitnessTotals(campaign, activity)
+      .then(totals =>
+        this.setState({ status: 'fetched', data: totals.distance })
+      )
+      .catch(error => {
+        this.setState({ status: 'failed' })
+        return Promise.reject(error)
+      })
   }
 
   render () {

--- a/source/components/total-duration/index.js
+++ b/source/components/total-duration/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import numbro from 'numbro'
-import { fetchCampaign, fetchCampaigns } from '../../api/campaigns'
+import { fetchFitnessTotals } from '../../api/fitness-totals'
 
 import Icon from 'constructicon/icon'
 import Loading from 'constructicon/loading'
@@ -26,58 +26,16 @@ class TotalDuration extends Component {
   }
 
   fetchData () {
-    const { campaign } = this.props
+    const { activity, campaign } = this.props
 
-    if (Array.isArray(campaign)) {
-      fetchCampaigns({ ids: campaign })
-        .then(data => {
-          let total = 0
-          data.map(campaign => {
-            total += this.calculateTotal(campaign)
-          })
-
-          this.setState({
-            status: 'fetched',
-            data: total
-          })
-        })
-        .catch(error => {
-          this.setState({ status: 'failed' })
-          return Promise.reject(error)
-        })
-    } else {
-      fetchCampaign(campaign)
-        .then(data => {
-          this.setState({
-            status: 'fetched',
-            data: this.calculateTotal(data)
-          })
-        })
-        .catch(error => {
-          this.setState({ status: 'failed' })
-          return Promise.reject(error)
-        })
-    }
-  }
-
-  calculateTotal (data) {
-    const { activity } = this.props
-    switch (typeof activity) {
-      case 'string':
-        return data.fitness_activity_overview[activity].duration_in_seconds
-      case 'object':
-        return activity.reduce(
-          (total, type) =>
-            (total += data.fitness_activity_overview[type].duration_in_seconds),
-          0
-        )
-      default:
-        return Object.keys(data.fitness_activity_overview).reduce(
-          (total, type) =>
-            (total += data.fitness_activity_overview[type].duration_in_seconds),
-          0
-        )
-    }
+    fetchFitnessTotals(campaign, activity)
+      .then(totals =>
+        this.setState({ status: 'fetched', data: totals.duration })
+      )
+      .catch(error => {
+        this.setState({ status: 'failed' })
+        return Promise.reject(error)
+      })
   }
 
   render () {


### PR DESCRIPTION
Added support for:

* Individual fitness leaderboards for campaign(s)
* Team fitness leaderboards for campaign(s)
* Total distance for campaign(s)
* Total elevation for campaign(s)

A lot of the diff below is splitting the original functions and tests up to allow JG equivalents to be added. The first commit is all that splitting up without actually adding anything, and the last 2 commits are where the changes are.