### PR TITLE
Include total distance in the page for both EDH and JG

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.24.0",
+  "version": "3.25.0",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/pages/everydayhero/index.js
+++ b/source/api/pages/everydayhero/index.js
@@ -26,6 +26,7 @@ export const deserializePage = page => {
       ? page.metrics.fitness
       : page.fitness_activity_overview,
     fitnessGoal: page.fitness_goal,
+    fitnessTotalDistance: getTotalDistance(page),
     groups: page.page_groups,
     hasUpdatedImage: page.meta && page.meta.has_set_image,
     id: page.id,
@@ -42,6 +43,18 @@ export const deserializePage = page => {
     url: page.url,
     uuid: page.uuid
   }
+}
+
+const getTotalDistance = page => {
+  if (page.fitness_activity_overview) {
+    const overview = page.fitness_activity_overview
+
+    return Object.keys(overview).reduce((total, key) => {
+      return total + overview[key].distance_in_meters
+    }, 0)
+  }
+
+  return lodashGet(page, 'metrics.fitness.total_in_meters', 0)
 }
 
 export const fetchPages = (params = required()) => {


### PR DESCRIPTION
* For EDH deserializePage, take the existing fitness_activity_overview (for v2) or metrics (for v3) and get out a fitnessTotalDistance
* For JG, if the includeFitness flag is present in fetchPage, it will also fetch the fitness totals for that page, and then similar to the above, the deserializePage will pull out a fitnessTotalDistance