### PR TITLE
Ensure Strava connect success calls callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.29.1",
+  "version": "3.29.2",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/components/provider-oauth-button/index.js
+++ b/source/components/provider-oauth-button/index.js
@@ -64,10 +64,13 @@ class ProviderOauthButton extends Component {
         addEventListener(
           'message',
           event => {
-            if (event.origin !== validSourceOrigin) {
-              return
+            const data = event.data
+            const isValid =
+              event.origin === validSourceOrigin || data === 'strava connected'
+
+            if (isValid) {
+              return this.handleSuccess(data)
             }
-            return this.handleSuccess(event.data)
           },
           false
         )


### PR DESCRIPTION
**Problem**

The `ProviderOauthButton` listens for post messages, and checks the domain the message came from matches the `redirectUri`. In the case of JG Strava, the `redirectUri` is a JG API endpoint that handles the connection and then redirects the user back to their page. In this case, the component never considers the connection successful, and never calls the `onSuccess` callback. 

**Solution**

My first attempt was to also any post messages from the current domain, but that then accepts other, non oauth connection, post messages, and the connection is marked as successful incorrectly. So I ended up just following the pattern in March for Water, where the data in the post message is simply "strava connected", so now it checks if the domain is valid OR if the data is "strava connected", so it handles both cases.