### PR TITLE
Ensure loading spinner keeps spinning while processing success

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.29.2",
+  "version": "3.29.3",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/components/provider-oauth-button/index.js
+++ b/source/components/provider-oauth-button/index.js
@@ -20,7 +20,8 @@ class ProviderOauthButton extends Component {
     this.providerUrl = this.providerUrl.bind(this)
 
     this.state = {
-      status: 'empty'
+      status: 'empty',
+      success: false
     }
   }
 
@@ -82,8 +83,9 @@ class ProviderOauthButton extends Component {
     const { onSuccess, provider } = this.props
 
     if (provider === 'justgiving') {
-      servicesAPI
-        .post('/v1/justgiving/oauth/connect', data)
+      Promise.resolve()
+        .then(() => this.setState({ success: true }))
+        .then(() => servicesAPI.post('/v1/justgiving/oauth/connect', data))
         .then(response => response.data)
         .then(data => ({
           token: data.access_token,
@@ -98,6 +100,7 @@ class ProviderOauthButton extends Component {
           return Promise.reject(error)
         })
     } else {
+      this.setState({ success: true })
       setTimeout(() => this.setState({ status: 'fetched' }), 500)
       onSuccess(data)
     }
@@ -116,8 +119,9 @@ class ProviderOauthButton extends Component {
 
     this.isPopupClosed = setInterval(() => {
       if (popupWindow.closed) {
+        const { success } = this.state
         clearInterval(this.isPopupClosed)
-        this.setState({ status: 'empty' })
+        this.setState({ status: success ? 'loading' : 'empty' })
 
         if (typeof onClose === 'function') {
           return onClose(popupWindow)


### PR DESCRIPTION
**Problem**

OAuth was successful, but we still needed to go off an get token from Services API. The issue is that the popup closed, which sets the status to empty, and the loading spinner stops, leaving the button in a weird hanging state where it looks like it is done, but nothing happens while it goes off and gets that token.

**Solution**

When OAuth is successful, it sets a success flag to true, so this means that when the window does close, if this flag is set, it sets the status to loading instead of empty, meaning the loading spinner keeps spinning until the request is finished.