### PR TITLE
Method for converting meters to a specified unit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.29.5",
+  "version": "3.29.6",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/utils/units/index.js
+++ b/source/utils/units/index.js
@@ -6,6 +6,27 @@ export const convertMetersToKm = data => data / 1000
 export const convertMetersToMiles = data => data * 0.000621371
 export const convertMetersToFeet = data => data * 3.28084
 
+export const convertMetersToUnit = (amount, unit) => {
+  if (isNaN(amount)) {
+    return 0
+  }
+
+  switch (unit) {
+    case 'km':
+    case 'kilometers':
+    case 'kilometres':
+      return convertMetersToKm(amount)
+    case 'mi':
+    case 'miles':
+      return convertMetersToMiles(amount)
+    case 'ft':
+    case 'feet':
+      return convertMetersToFeet(amount)
+    default:
+      return Number(amount)
+  }
+}
+
 export const convertToMeters = (amount, unit = 'm') => {
   if (isNaN(amount)) {
     return 0


### PR DESCRIPTION
Purpose of this is that in EDH, and in our pageSummaryWhat JG hack, the fitness goal is not necessarily stored in meters. With this method, we can then take the total distance in meters and convert it into the same unit as the goal, so we can consistently compare for things like progress bars and badges.