### PR TITLE
Add fetchTeamBySlug method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.30.0",
+  "version": "3.31.0",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/pages/everydayhero/index.js
+++ b/source/api/pages/everydayhero/index.js
@@ -63,7 +63,9 @@ export const fetchPages = (params = required()) => {
   const { allPages, ...finalParams } = params
   const mappings = { type: 'type' }
   const transforms = allPages
-    ? {}
+    ? {
+      ids: v => (Array.isArray(v) ? v.join(',') : v)
+    }
     : {
       type: v => (v === 'individual' ? 'user' : v)
     }

--- a/source/api/teams/index.js
+++ b/source/api/teams/index.js
@@ -4,6 +4,7 @@ import {
   deserializeTeam as deserializeJGTeam,
   fetchTeams as fetchJGTeams,
   fetchTeam as fetchJGTeam,
+  fetchTeamBySlug as fetchJGTeamBySlug,
   createTeam as createJGTeam,
   joinTeam as joinJGTeam
 } from './justgiving'
@@ -12,6 +13,7 @@ import {
   deserializeTeam as deserializeEDHTeam,
   fetchTeams as fetchEDHTeams,
   fetchTeam as fetchEDHTeam,
+  fetchTeamBySlug as fetchEDHTeamBySlug,
   createTeam as createEDHTeam,
   joinTeam as joinEDHTeam
 } from './everydayhero'
@@ -24,6 +26,9 @@ export const fetchTeams = params =>
 
 export const fetchTeam = params =>
   isJustGiving() ? fetchJGTeam(params) : fetchEDHTeam(params)
+
+export const fetchTeamBySlug = params =>
+  isJustGiving() ? fetchJGTeamBySlug(params) : fetchEDHTeamBySlug(params)
 
 export const createTeam = params =>
   isJustGiving() ? createJGTeam(params) : createEDHTeam(params)

--- a/source/api/teams/justgiving/index.js
+++ b/source/api/teams/justgiving/index.js
@@ -10,6 +10,14 @@ export const deserializeTeam = team => {
     id: team.teamGuid,
     leader: get(team, 'captain.firstName'),
     name: team.name,
+    members: get(team, 'membership.members', []).map(member => ({
+      userId: member.userGuid,
+      image: member.profileImage,
+      id: member.fundraisingPageGuid,
+      name: member.fundraisingPageName,
+      slug: member.fundraisingPageShortName,
+      status: member.fundraisingPageStatus
+    })),
     pages: team.numberOfSupporters,
     raised: get(team, 'donationSummary.totalAmount'),
     slug: team.shortName,
@@ -32,6 +40,10 @@ export const fetchTeams = (options = required()) => {
 
 export const fetchTeam = (id = required()) => {
   return client.get(`/campaigns/v1/teams/${id}/full`)
+}
+
+export const fetchTeamBySlug = (slug = required()) => {
+  return client.get(`/campaigns/v1/teams/by-short-name/${slug}/full`)
 }
 
 export const createTeam = params => {


### PR DESCRIPTION
Created corresponding EDH and JG methods that fetch a team by slug (also requires country code and campaign slug for EDH). Each of these methods returns the team details, as well as a list of the members in each team. I also updated the deserializers to deserialize the team members if present.

JG returns all our team members in one request, despite missing some required info (see below), while EDH requires 3 requests to get the team info and the included team members.

There are some things to come, for example, JG team members don't include their amount raised, donate url etc, but I wanted to get this out so we can at least push forward in SiteBuilder and handle the fetching of the team page in a consistent way.