### PR TITLE
Add offline amount to JG update page method

### DIFF
--- a/source/api/pages/justgiving/index.js
+++ b/source/api/pages/justgiving/index.js
@@ -272,6 +272,7 @@ export const updatePage = (
     authType = 'Basic',
     image,
     name,
+    offline,
     story,
     summaryWhat,
     summaryWhy,
@@ -298,6 +299,12 @@ export const updatePage = (
         put(
           `/v1/fundraising/pages/${slug}/pagetitle`,
           { pageTitle: name },
+          config
+        ),
+      offline &&
+        put(
+          `/v1/fundraising/pages/${slug}/offline`,
+          { amount: offline },
           config
         ),
       story &&


### PR DESCRIPTION
Just in case we need it one day, e.g. JRFH

If we want (say we want to add this to our custom supporter pages in site builder), we could add a related method for EDH, but it would need a new services API endpoint that proxies to the internal API, and does a user auth check first, similar to MDS 💡 