### PR TITLE
remove leaderboard endpoints from page totals

### DIFF
--- a/source/api/pages-totals/justgiving/index.js
+++ b/source/api/pages-totals/justgiving/index.js
@@ -10,11 +10,6 @@ import { currencyCode } from '../../../utils/currencies'
 const fetchEvent = id =>
   get(`v1/event/${id}/pages`).then(response => response.totalFundraisingPages)
 
-const fetchCampaign = id =>
-  servicesAPI
-    .get(`/v1/justgiving/campaigns/${id}/leaderboard`)
-    .then(({ data }) => data.meta.totalResults)
-
 export const fetchPagesTotals = (params = required()) => {
   switch (dataSource(params)) {
     case 'event':
@@ -25,31 +20,11 @@ export const fetchPagesTotals = (params = required()) => {
       return Promise.all(eventIds.map(getUID).map(fetchEvent)).then(events =>
         events.reduce((acc, total) => acc + total, 0)
       )
-    case 'campaign':
-      const campaignIds = Array.isArray(params.campaign)
-        ? params.campaign
-        : [params.campaign]
-
-      return Promise.all(campaignIds.map(getUID).map(fetchCampaign)).then(
-        campaigns => campaigns.reduce((acc, total) => acc + total, 0)
-      )
     default:
-      return get(
-        'donationsleaderboards/v1/leaderboard',
-        {
-          ...params,
-          currencyCode: currencyCode(params.country)
-        },
-        {
-          mappings: {
-            charity: 'charityIds',
-            campaign: 'campaignGuids',
-            page: 'pageGuids',
-            excludePageIds: 'excludePageGuids',
-            limit: 'take'
-          }
-        },
-        { paramsSerializer }
-      ).then(data => data.totalResults)
+      return Promise.reject(
+        new Error(
+          'This is method currently only supports using the event parameter for JustGiving'
+        )
+      )
   }
 }

--- a/source/api/pages-totals/justgiving/index.js
+++ b/source/api/pages-totals/justgiving/index.js
@@ -23,7 +23,7 @@ export const fetchPagesTotals = (params = required()) => {
     default:
       return Promise.reject(
         new Error(
-          'This is method currently only supports using the event parameter for JustGiving'
+          'This method currently only supports using the event parameter for JustGiving'
         )
       )
   }


### PR DESCRIPTION
Leaderboard endpoints in JG only return number of pages with donations, not actual pages in campaign. 

Here is an example:
https://gsk-uk-staging.blackbaud-sites.com/trek-for-kids

On this page you can see a fetch for leaderboards that only returns 11 results.
https://api.staging.justgiving.com/donationsleaderboards/v1/leaderboard?campaignGuids=2cd19d17-9cdd-4796-95f0-02ea804466f5&take=100&currencyCode=GBP

However you can also see us fetching pages from the event, and we get 12 (an additional page that has no donations attached).

This could be a bit confusing, so I suggest we remove the leaderboard endpoints entirely since they are not accurate for this use. I do have a ticket out to add page totals to the campaign endpoint, so once that is added we could use that for the campaign params:
https://justgiving.atlassian.net/browse/DIG-121