### PR TITLE
Remove leaderboard endpoints from JG page totals

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.41.2",
+  "version": "3.41.3",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/pages-totals/__tests__/totals-test.js
+++ b/source/api/pages-totals/__tests__/totals-test.js
@@ -78,16 +78,5 @@ describe('Fetch Pages Totals', () => {
         done()
       })
     })
-
-    it('uses the correct url to fetch totals for a campaign', done => {
-      fetchJGPagesTotals({ campaign: 12345 })
-      moxios.wait(function () {
-        const request = moxios.requests.mostRecent()
-        expect(request.url).to.include(
-          'https://api.blackbaud.services/v1/justgiving/campaigns/12345/leaderboard'
-        )
-        done()
-      })
-    })
   })
 })

--- a/source/api/pages-totals/justgiving/index.js
+++ b/source/api/pages-totals/justgiving/index.js
@@ -1,19 +1,8 @@
-import { get, servicesAPI } from '../../../utils/client'
-import {
-  getUID,
-  required,
-  dataSource,
-  paramsSerializer
-} from '../../../utils/params'
-import { currencyCode } from '../../../utils/currencies'
+import { get } from '../../../utils/client'
+import { getUID, required, dataSource } from '../../../utils/params'
 
 const fetchEvent = id =>
   get(`v1/event/${id}/pages`).then(response => response.totalFundraisingPages)
-
-const fetchCampaign = id =>
-  servicesAPI
-    .get(`/v1/justgiving/campaigns/${id}/leaderboard`)
-    .then(({ data }) => data.meta.totalResults)
 
 export const fetchPagesTotals = (params = required()) => {
   switch (dataSource(params)) {
@@ -25,31 +14,11 @@ export const fetchPagesTotals = (params = required()) => {
       return Promise.all(eventIds.map(getUID).map(fetchEvent)).then(events =>
         events.reduce((acc, total) => acc + total, 0)
       )
-    case 'campaign':
-      const campaignIds = Array.isArray(params.campaign)
-        ? params.campaign
-        : [params.campaign]
-
-      return Promise.all(campaignIds.map(getUID).map(fetchCampaign)).then(
-        campaigns => campaigns.reduce((acc, total) => acc + total, 0)
-      )
     default:
-      return get(
-        'donationsleaderboards/v1/leaderboard',
-        {
-          ...params,
-          currencyCode: currencyCode(params.country)
-        },
-        {
-          mappings: {
-            charity: 'charityIds',
-            campaign: 'campaignGuids',
-            page: 'pageGuids',
-            excludePageIds: 'excludePageGuids',
-            limit: 'take'
-          }
-        },
-        { paramsSerializer }
-      ).then(data => data.totalResults)
+      return Promise.reject(
+        new Error(
+          'This method currently only supports using the event parameter for JustGiving'
+        )
+      )
   }
 }


### PR DESCRIPTION
Leaderboard endpoints in JG only return number of pages with donations, not actual pages in campaign.

Here is an example:
https://gsk-uk-staging.blackbaud-sites.com/trek-for-kids

On this page you can see a fetch for leaderboards that only returns 11 results.
https://api.staging.justgiving.com/donationsleaderboards/v1/leaderboard?campaignGuids=2cd19d17-9cdd-4796-95f0-02ea804466f5&take=100&currencyCode=GBP

However you can also see us fetching pages from the event, and we get 12 (an additional page that has no donations attached).

This could be a bit confusing, so I suggest we remove the leaderboard endpoints entirely since they are not accurate for this use. I do have a ticket out to add page totals to the campaign endpoint, so once that is added we could use that for the campaign params:
https://justgiving.atlassian.net/browse/DIG-121