### PR TITLE
use leaderboard endpoint for fetching multiple campaigns donation totals

### DIFF
--- a/source/api/donation-totals/__tests__/totals-test.js
+++ b/source/api/donation-totals/__tests__/totals-test.js
@@ -107,6 +107,17 @@ describe('Fetch Donation Totals', () => {
       })
     })
 
+    it('uses the correct url to fetch totals for multiple campaigns', done => {
+      fetchJGDonationTotals({ campaign: ['1234', '5678'] })
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent()
+        expect(request.url).to.equal(
+          'https://api.justgiving.com/donationsleaderboards/v1/totals?campaignGuids=1234&campaignGuids=5678&currencyCode=GBP'
+        )
+        done()
+      })
+    })
+
     it('uses the correct url to fetch totals for a charity', done => {
       fetchJGDonationTotals({ charity: 1234 })
       moxios.wait(() => {

--- a/source/api/donation-totals/justgiving/index.js
+++ b/source/api/donation-totals/justgiving/index.js
@@ -51,17 +51,15 @@ export const fetchDonationTotals = (params = required()) => {
       })
 
       return Array.isArray(params.campaign)
-        ? Promise.all(params.campaign.map(getUID).map(fetchCampaign))
-          .then(campaigns => campaigns.map(mapTotals))
-          .then(campaigns =>
-            campaigns.reduce(
-              (acc, { totalRaised, totalResults }) => ({
-                totalRaised: acc.totalRaised + totalRaised,
-                totalResults: acc.totalResults + totalResults
-              }),
-              { totalRaised: 0, totalResults: 0 }
-            )
-          )
+        ? client.get(
+          'donationsleaderboards/v1/totals',
+          {
+            campaignGuids: params.campaign.map(getUID),
+            currencyCode: currencyCode(params.country)
+          },
+          {},
+          { paramsSerializer }
+        )
         : fetchCampaign(getUID(params.campaign)).then(mapTotals)
   }
 }


### PR DESCRIPTION
For JG, we can now use leaderboard endpoint to fetch multiple campaigns in one request, rather than loop through campaigns individually. Am doing this currently in GSK for the rollup map:

https://gsk-staging.blackbaud-sites.com/pages/map
https://github.com/blackbaud-services/gsk/blob/master/source/lib/justgiving/index.js#L40

Also, did a local update by building this update in supporticon over to my GSK project to make sure would work when supplying array of campaigns ids.