### PR TITLE
Event leaderboard fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.43.1",
+  "version": "3.43.2",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/leaderboard/justgiving/index.js
+++ b/source/api/leaderboard/justgiving/index.js
@@ -5,6 +5,7 @@ import {
   getUID,
   required,
   dataSource,
+  isEmpty,
   paramsSerializer
 } from '../../../utils/params'
 import { currencySymbol, currencyCode } from '../../../utils/currencies'
@@ -13,7 +14,7 @@ import { currencySymbol, currencyCode } from '../../../utils/currencies'
  * @function fetches fundraising pages ranked by funds raised
  */
 export const fetchLeaderboard = (params = required()) => {
-  if (params.campaign && params.allPages) {
+  if (!isEmpty(params.campaign) && params.allPages) {
     return recursivelyFetchJGLeaderboard(
       getUID(params.campaign),
       params.q,
@@ -23,6 +24,12 @@ export const fetchLeaderboard = (params = required()) => {
 
   switch (dataSource(params)) {
     case 'event':
+      if (params.type === 'team') {
+        return Promise.reject(
+          new Error('Team leaderboards by event are not supported')
+        )
+      }
+
       return get(
         '/v1/events/leaderboard',
         {

--- a/source/utils/params/index.js
+++ b/source/utils/params/index.js
@@ -4,7 +4,7 @@ export const required = () => {
   throw new Error('Required parameter not supplied')
 }
 
-const isEmpty = val => {
+export const isEmpty = val => {
   if (Array.isArray(val)) {
     return val.length === 0
   } else {


### PR DESCRIPTION
A couple of issues were raised w/ event leaderboards...

**1. Individual event leaderboards were erroring**

This was because although campaign was an empty array, it was trying to recursively fetch a campaign leaderboard, and was failing

**2. Team event leaderboards were showing individuals**

This was because this fell through to the event leaderboard "case", but team leaderboards are not supported for events (as far as I know)