### PR TITLE
Handle pages created outside of events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.45.2",
+  "version": "3.45.3",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/pages/justgiving/index.js
+++ b/source/api/pages/justgiving/index.js
@@ -204,7 +204,7 @@ export const createPage = ({
   title = required(),
   token = required(),
   slug,
-  activityType,
+  activityType = 'othercelebration',
   attribution,
   authType = 'Basic',
   campaignId,
@@ -237,7 +237,15 @@ export const createPage = ({
     return put(
       '/v1/fundraising/pages',
       {
-        activityType,
+        ...(eventId
+          ? {
+            eventId
+          }
+          : {
+            activityType,
+            eventDate,
+            eventName: eventName || title
+          }),
         attribution,
         campaignGuid: campaignGuid || campaignId,
         causeId,
@@ -248,9 +256,6 @@ export const createPage = ({
         consistentErrorResponses,
         currency,
         customCodes,
-        eventDate,
-        eventId,
-        eventName,
         expiryDate,
         images: images.length
           ? images


### PR DESCRIPTION
Rather than pass in defaults in via the create page form, just setting some nicer defaults to handle creating a page in it's own event.

Is `eventId` passed in?
- Yes: forward that through in the request and add the page to the event
- No: pass in `activityType` (with an "othercelebration" default), `eventName` (defaulting to the page name) and `eventDate` (no current default)