### PR TITLE
Default to mins and make labels smaller

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.45.3",
+  "version": "3.45.4",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/components/create-fitness-form/index.js
+++ b/source/components/create-fitness-form/index.js
@@ -330,10 +330,11 @@ const form = props => {
           durationUnit: {
             type: 'select',
             label: '​',
-            options: ['seconds', 'minutes', 'hours', 'days'].map(value => ({
-              value,
-              label: value
-            }))
+            options: [
+              { value: 'minutes', label: 'mins' },
+              { value: 'hours', label: 'hrs' },
+              { value: 'days', label: 'days' }
+            ]
           }
         }),
         ...(props.includeElevation && {


### PR DESCRIPTION
* Default to minutes
* Make labels shorter so they fit nicer in form

NOTE: there is another issue in SB where the `type` prop isn't being set, and things are just being logged as `walk` as it is the default prop. I think we need to handle this in SB rather than doing something here in Supporticon?