### PR TITLE
add charities to campaign deserializer

### DIFF
--- a/source/api/campaigns/justgiving/index.js
+++ b/source/api/campaigns/justgiving/index.js
@@ -23,6 +23,7 @@ export const fetchCampaignGroups = (id = required()) =>
   Promise.reject(new Error('This method is not supported for JustGiving'))
 
 export const deserializeCampaign = campaign => ({
+  charities: campaign.charities,
   donateUrl: [
     baseUrl('link'),
     'v1/campaign/donate/campaignGuid',


### PR DESCRIPTION
Small change to just add list of charities to the deserializer since this is returned in v2 campaign endpoint:
https://api.staging.justgiving.com/campaigns/v2/campaign/875fc035-b21d-4f93-bbe6-5d44be76a1a8