### PR TITLE
add tags on page creation and page fetch

### DIFF
--- a/source/api/pages/justgiving/index.js
+++ b/source/api/pages/justgiving/index.js
@@ -76,6 +76,7 @@ export const deserializePage = page => {
     raised: onlineAmount + offlineAmount,
     slug: shortName,
     story: page.story || page.ProfileWhat || page.ProfileWhy,
+    tags: page.tags || [],
     target: parseFloat(
       page.fundraisingTarget ||
         page.TargetAmount ||
@@ -157,10 +158,15 @@ export const fetchPage = (page = required(), slug, options = {}) => {
 
   const fetchers = [
     get(`/v1/fundraising/${endpoint}/${page}`),
-    options.includeFitness && fetchPageFitness(page)
+    options.includeFitness && fetchPageFitness(page),
+    options.includeTags && fetchPageTags(page)
   ]
 
-  return Promise.all(fetchers).then(([page, fitness]) => ({ ...page, fitness }))
+  return Promise.all(fetchers).then(([page, fitness, tags]) => ({
+    ...page,
+    fitness,
+    ...tags
+  }))
 }
 
 export const fetchUserPages = ({
@@ -187,6 +193,10 @@ export const fetchUserPages = ({
     .then(pages => filterByCampaign(pages, campaign))
     .then(pages => filterByCharity(pages, charity))
     .then(pages => filterByEvent(pages, event))
+}
+
+export const fetchPageTags = page => {
+  return get(`v1/tags/${page}`)
 }
 
 const fetchPageFitness = page => {
@@ -228,6 +238,7 @@ export const createPage = ({
   story,
   summaryWhat,
   summaryWhy,
+  tags,
   target,
   teamId,
   theme,
@@ -270,6 +281,7 @@ export const createPage = ({
         pageTitle: title,
         reference,
         rememberedPersonReference,
+        tags,
         targetAmount: target,
         teamId,
         theme,

--- a/source/api/pages/readme.md
+++ b/source/api/pages/readme.md
@@ -138,6 +138,27 @@ See [the API documentation](http://developer.everydayhero.com/pages/#create-an-i
 - `groupValues` (Hash/Array) Campaign group values for the page
 - `giftAid` (Boolean) If page eligable for gift aid
 - `inviteToken` (String) Team invite token
+- `tags` (Array of Objects) Containing the following:
+  - `id` (String) Create unique id, needed for reference when filtering or creating leaderboards from tags
+  - `label` (String) Tag Label
+  - `value` (String) Value of Tag
+  - `aggregation` (Array of Object) Settings for how tag is grouped
+    - `segment` (String)
+    - `measurementDomains` (Array) Accepts fundraising:donations_received, ride:distance, walk:distance, any:distance
+
+**Example of tag object shape**
+```javascript
+  {
+    id: '123456',
+    label: 'branchName',
+    value: 'London',
+    aggregation: [{
+      segment: `Page:Campaign:${process.env.CAMPAIGN_GUID}`,
+      measurementDomains: ['fundraising:donations_received', 'any:distance']
+    }]
+  }
+```
+
 
 **Returns**
 


### PR DESCRIPTION
Using tags for TSB project, so thought it would be a good idea to get these in Supporticon. Includes adding the following:
1) JG API now accepts tags to be passed on page creation, added description on what is needed in readme

2) Added option to fetch tags when fetching page

3) Added tags property to page deserializer