### PR TITLE
only perform string replace if label is string

### DIFF
--- a/source/components/provider-oauth-button/index.js
+++ b/source/components/provider-oauth-button/index.js
@@ -248,7 +248,9 @@ class ProviderOauthButton extends Component {
       >
         <Icon name={icon} spin={isLoading} size={1.5} />
         <span>
-          {isLoading ? label.replace('Connect', 'Connecting') : label}
+          {isLoading && typeof label === 'string'
+            ? label.replace('Connect', 'Connecting')
+            : label}
         </span>
       </Button>
     )


### PR DESCRIPTION
Found an issue with oauth button if I use a custom label prop that is not a string. We are performing a string replace on the label, but in the docs we say we allow any type, not just string. In the video below I am using a custom label prop with jsx, so it creates an error from Supporticon:
https://drive.google.com/file/d/1pk5zZPVfkB5_00LPW8JeABC1ai_Sh2i4/view

Strange thing is we have done the same elsewhere, and this only seems to give me an error locally, but seems like it should always cause a problem. Added conditional to only do the string replace if label is a string.