### PR TITLE
Enforce JG team is created/updated without disallowed characters in name

### DIFF
--- a/source/api/teams/justgiving/index.js
+++ b/source/api/teams/justgiving/index.js
@@ -7,6 +7,8 @@ import { fetchPage, deserializePage } from '../../pages'
 import { paramsSerializer, required } from '../../../utils/params'
 import { baseUrl, imageUrl, parseText } from '../../../utils/justgiving'
 
+export const teamNameRegex = /[^\w\s'"!?£$€¥.,-]/gi
+
 export const deserializeTeam = team => {
   const members = get(team, 'membership.members', [])
   const membersFitness = get(team, 'fitness.pages', [])
@@ -138,7 +140,7 @@ export const createTeam = params => {
     campaignGuid: campaignId,
     captainPageShortName: captainSlug,
     coverPhotoId,
-    name,
+    name: name.replace(teamNameRegex, '').substring(0, 255),
     story,
     targetCurrency,
     targetType,
@@ -209,7 +211,7 @@ export const updateTeam = (
     teamGuid: id,
     coverPhotoImageId: image,
     currency,
-    name,
+    name: name.replace(teamNameRegex, '').substring(0, 255),
     story,
     target
   }


### PR DESCRIPTION
Olly mentioned that team names with apostrophes would cause the API call to fail, though looks like apostrophes weren't actually the culprit.

A bit of digging turned up [this regex](https://github.com/JustGiving/JG.Campaigns/blob/master/src/JG.Pages.API/Commands/Teams/SetName/SetNameCommandValidator.cs#L12) and [this length validation](https://github.com/JustGiving/JG.Campaigns/blob/master/src/JG.Pages.API/Infrastructure/Constants.cs#L18) that cause the `invalid-request-body-property-name` error response. The regex used here is modified a bit for JS.

I was able to create & update [a team page with the name of `Team 1'-_"$£¥€!?,.`](https://www.staging.justgiving.com/team/test-team-32f2dd50-471d-4ea6-80d5-384ff5e10cec) by following the rules.