### PR TITLE
Use JG images API instead of filestack for image upload

### DIFF
--- a/source/api/images/__tests__/images-test.js
+++ b/source/api/images/__tests__/images-test.js
@@ -1,0 +1,52 @@
+import moxios from 'moxios'
+import { uploadImage } from '..'
+import { imagesAPI, servicesAPI } from '../../../utils/client'
+
+describe('Uploading images', () => {
+  beforeEach(() => {
+    moxios.install(imagesAPI)
+    moxios.install(servicesAPI)
+  })
+
+  afterEach(() => {
+    moxios.uninstall(imagesAPI)
+    moxios.uninstall(servicesAPI)
+  })
+
+  it('uses the correct url for external images', done => {
+    uploadImage('https://example.com/image.jpg')
+
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent()
+      expect(request.url).to.eql(
+        'https://api.blackbaud.services/v1/justgiving/images'
+      )
+      expect(request.config.method).to.eql('post')
+      done()
+    })
+  })
+
+  it('uses the correct url for base64 URLs', done => {
+    uploadImage(
+      'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
+    )
+
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent()
+      expect(request.url).to.eql('https://images.justgiving.com/image')
+      expect(request.config.method).to.eql('post')
+      done()
+    })
+  })
+
+  it('uses the correct url for files', done => {
+    uploadImage({ name: 'image.jpg', size: 123 })
+
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent()
+      expect(request.url).to.eql('https://images.justgiving.com/image')
+      expect(request.config.method).to.eql('post')
+      done()
+    })
+  })
+})

--- a/source/api/images/index.js
+++ b/source/api/images/index.js
@@ -1,0 +1,18 @@
+import { imagesAPI, servicesAPI } from '../../utils/client'
+import { handleImageFile, isBase64EncodedUrl } from '../../utils/images'
+import { required } from '../../utils/params'
+
+export const uploadImage = (image = required()) =>
+  handleUploadImage(image)
+    .then(response => response.data.url)
+    .then(url => url && url.replace('http://', 'https://'))
+
+const handleUploadImage = image => {
+  if (typeof image === 'string' && !isBase64EncodedUrl(image)) {
+    return servicesAPI.post('/v1/justgiving/images', { image })
+  }
+
+  return imagesAPI.post('/image', handleImageFile(image), {
+    headers: { 'Content-Type': 'multipart/form-data' }
+  })
+}

--- a/source/components/create-post-form/index.js
+++ b/source/components/create-post-form/index.js
@@ -4,7 +4,7 @@ import withForm from 'constructicon/with-form'
 import get from 'lodash/get'
 import form from './form'
 import { createPost } from '../../api/posts'
-import { uploadToFilestack } from 'constructicon/lib/filestack'
+import { uploadImage } from '../../api/images'
 
 import Form from 'constructicon/form'
 import Grid from 'constructicon/grid'
@@ -35,7 +35,7 @@ class CreatePostForm extends React.Component {
     form.submit().then(data =>
       Promise.resolve()
         .then(() => this.setState({ status: 'fetching' }))
-        .then(() => data.image && uploadToFilestack(data.image, pageId))
+        .then(() => data.image && uploadImage(data.image))
         .then(image => createPost({ ...data, image, pageId, token, userId }))
         .then(data => {
           this.setState({ status: 'fetched' })

--- a/source/utils/client/index.js
+++ b/source/utils/client/index.js
@@ -40,6 +40,7 @@ export const updateClient = (options = {}) => {
   updateServicesAPIClient()
   updateMetadataAPIClient()
   updateJGIdentityClient()
+  updateImagesAPIClient()
 }
 
 export const getBaseURL = () => instance.defaults.baseURL
@@ -76,6 +77,17 @@ const updateMetadataAPIClient = () => {
       : 'https://mds-engineering.everydayhero.com'
 }
 
+// JG Images Client
+export const imagesAPI = axios.create({
+  baseURL: 'https://images.justgiving.com'
+})
+
+const updateImagesAPIClient = () => {
+  imagesAPI.defaults.baseURL = isStaging()
+    ? 'https://images.staging.justgiving.com'
+    : 'https://images.justgiving.com'
+}
+
 // JG Identity Client
 export const jgIdentityClient = axios.create({
   baseURL: 'https://identity.justgiving.com'
@@ -100,5 +112,6 @@ export default {
   isStaging,
   servicesAPI,
   metadataAPI,
+  imagesAPI,
   jgIdentityClient
 }

--- a/source/utils/images/index.js
+++ b/source/utils/images/index.js
@@ -1,0 +1,19 @@
+import { dataURIToBlob } from 'constructicon/lib/files'
+
+export const isBase64EncodedUrl = url =>
+  /data:image\/([a-zA-Z]*);base64,([^"]*)/.test(url)
+
+export const handleImageFile = (image, name = 'file') => {
+  if (typeof window !== 'undefined') {
+    const formData = new window.FormData()
+    const file = isBase64EncodedUrl(image) ? dataURIToBlob(image) : image
+
+    formData.append(name, file)
+
+    return formData
+  }
+
+  return Promise.reject(
+    new Error('This method must be called from the browser')
+  )
+}


### PR DESCRIPTION
It proxies to services API for external URLs for CORS support, but otherwise submits form data directly for files (and base64 URLs converted to Blobs).