### PR TITLE
Donation feed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.47.1",
+  "version": "3.47.2",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/feeds/justgiving/index.js
+++ b/source/api/feeds/justgiving/index.js
@@ -7,10 +7,15 @@ export const fetchDonationFeed = ({
   charity,
   event,
   page,
+  pageShortName,
   donationRef
 }) => {
   if (donationRef) {
     return fetchDonationFeedByRef(donationRef)
+  }
+
+  if (pageShortName) {
+    return fetchDonationsByShortName(pageShortName)
   }
 
   if (charity || campaign || event || page) {
@@ -20,7 +25,7 @@ export const fetchDonationFeed = ({
   }
 
   return Promise.reject(
-    'You must pass a charity UID, event ID, page ID, campaign GUID or donationRef for this method'
+    'You must pass a charity UID, event ID, page ID, page short name, campaign GUID or donationRef for this method'
   )
 }
 
@@ -40,6 +45,11 @@ export const fetchDonations = ({ event, charity, campaign, page }) =>
 
 const fetchDonationFeedByRef = ref =>
   get(`v1/donation/ref/${ref}`).then(data => data.donations)
+
+const fetchDonationsByShortName = pageShortName =>
+  get(`v1/fundraising/pages/${pageShortName}/donations`).then(
+    data => data.donations
+  )
 
 export const deserializeDonation = donation => {
   const isFromDonationsAPI = !!donation.donationId


### PR DESCRIPTION
Small update to allow us to use pageShortName and different endpoint when fetching a page donation feed. When using Id, which routes through services api endpoint, it is not actually returning the 3rd party refs. I am needing the ref because I am attaching it to self donors so we can have a self donor badge.

For example:
https://tsb-corporate-hub.blackbaud-sites.com/fundraising/wes-test-page

Uses the following endpoint: 
https://api-staging.blackbaud.services/v1/justgiving/donations?fundraisingPageId=9598360

This does not seem to return the 3rd party ref. However, if I use the following JG endpoint by shortname:
https://api.staging.justgiving.com/808dbb87/v1/fundraising/pages/wes-test-page/donations

I do then get 3rd party ref.

Quick video showing this update locally:
https://drive.google.com/file/d/1ZDvshPUPg6NgnrI__aAlX6doi5HsGnlO/view