### PR TITLE
Filter out JG fitness activities from posts (timeline) response

### DIFF
--- a/source/api/posts/justgiving/index.js
+++ b/source/api/posts/justgiving/index.js
@@ -42,6 +42,7 @@ export const fetchPosts = ({
             message
             type
             createdAt
+            fitnessActivity { activityType }
             media {
               __typename
               ... on ImageMedia { url caption }
@@ -69,7 +70,7 @@ export const fetchPosts = ({
           allPosts: true
         })
       } else {
-        return updatedResults
+        return updatedResults.filter(post => !post.fitnessActivity)
       }
     })
 }


### PR DESCRIPTION
In the case of fitness activities tracked via Strava or created via the GraphQL API, they'll show up in this response.