### PR TITLE
Add consistent segmentation key/value object to EDH + JG pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.48.4",
+  "version": "3.49.0",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/pages/everydayhero/index.js
+++ b/source/api/pages/everydayhero/index.js
@@ -48,6 +48,7 @@ export const deserializePage = page => {
     name: page.name,
     owner: lodashGet(page, 'supporter.name') || page.owner_uid || page.user_id,
     raised: amountInCents / 100,
+    segmentation: deserializeSegmentation(page.page_groups),
     slug: page.slug,
     story: page.story,
     target:
@@ -58,6 +59,16 @@ export const deserializePage = page => {
     url: page.url,
     uuid: page.uuid
   }
+}
+
+const deserializeSegmentation = (groups = []) => {
+  return groups.reduce(
+    (segments, group) => ({
+      ...segments,
+      [group.key]: group.value
+    }),
+    {}
+  )
 }
 
 export const fetchPages = (params = required()) => {

--- a/source/api/pages/justgiving/index.js
+++ b/source/api/pages/justgiving/index.js
@@ -85,6 +85,7 @@ export const deserializePage = page => {
     raised: onlineAmount + offlineAmount,
     raisedOnline: onlineAmount,
     raisedOffline: offlineAmount,
+    segmentation: deserializeSegmentation(page.tags),
     slug: shortName,
     story: page.story || page.ProfileWhat || page.ProfileWhy,
     tags: page.tags || [],
@@ -103,6 +104,18 @@ export const deserializePage = page => {
     url: page.Link || page.PageUrl || `${baseUrl()}/fundraising/${shortName}`,
     uuid: page.pageGuid || page.fundraisingPageGuid
   }
+}
+
+const deserializeSegmentation = (tags = []) => {
+  return tags.reduce((segments, tag) => {
+    const key = lodashGet(tag, 'tagDefinition.id')
+    const value = lodashGet(tag, 'value')
+
+    return {
+      ...segments,
+      [key]: value
+    }
+  }, {})
 }
 
 export const fetchPages = (params = required()) => {


### PR DESCRIPTION
Based on tags or group values, this adds a segmentation field to a deserialized page object. The idea is this is just a simple consistent key/value object that we can then use to achieve the supporter page segmentation relatively easily without having to worry about differences between tags vs groups.

If there are no group values, or the includeTags flag wasn't present on the fetchPage, it will just return an empty object.