### PR TITLE
Handle ui webview OAuth redirection

### DIFF
--- a/source/utils/params/index.js
+++ b/source/utils/params/index.js
@@ -62,3 +62,21 @@ export const isURL = str => {
 }
 
 export const isEqual = (a, b) => String(a) === String(b)
+
+export const parseUrlParams = () => {
+  if (typeof window === 'undefined') {
+    return {}
+  }
+
+  const paramsArray = ['search', 'hash']
+    .map(param => window.location[param].substring(1))
+    .filter(Boolean)
+    .join('&')
+    .split('&')
+
+  return paramsArray.reduce(function (params, part) {
+    var [key, val] = part.split('=')
+    params[decodeURIComponent(key)] = decodeURIComponent(val)
+    return params
+  }, {})
+}


### PR DESCRIPTION
After the [recent update](https://github.com/blackbaud-services/oauth.blackbaud-sites.com/commit/2ee72dbde29be1c0c3ad05584f3b970f021de7bd) to our generic OAuth redirect handling script, I've updated the `ProviderOAuthButton` component to handle parsing combined `hash` and `search` params.

I've also updated the initial component load to trigger success if URL params are present (to the `homeUrl` handle redirection). This will then be a one-liner (adding the `homeUrl` prop) in any project using this component