### PR TITLE
Handle OAuth success loading state

### DIFF
--- a/source/utils/promise/index.js
+++ b/source/utils/promise/index.js
@@ -1,0 +1,15 @@
+export const toPromise = f =>
+  function () {
+    return new Promise((resolve, reject) => {
+      const result = f.apply(null, Array.from(arguments))
+      try {
+        return result.then(resolve, reject) // promise.
+      } catch (e) {
+        if (e instanceof TypeError) {
+          resolve(result) // resolve naked value.
+        } else {
+          reject(e) // pass unhandled exception to caller.
+        }
+      }
+    })
+  }


### PR DESCRIPTION
**Problem:**
This has been a pet peeve of mine for a while: The OAuth dance is done so the icon turns into a ✅ but another call has to be made to the relevant API to fetch the user data and it just sits there and the user doesn't know what's going on.

**Solution:**
We check (and handle the exception) that the `onSuccess` function returns a promise, and if it does it waits for that promise to resolve to stop showing the loading spinner. Similar to other projects I've opted to update the loading message text at that point to show the user we're doing something else (gives them a reason to keep waiting?). In the case that the `onSuccess` function doesn't return a promise, it will go straight to `fetched` so we'll have the same situation as it stands today.

![2020-07-16 13-59-29 2020-07-16 14_02_50](https://user-images.githubusercontent.com/729085/87625264-0fe12f00-c76d-11ea-929a-998ca9a4dd3f.gif)
