### PR TITLE
JG createPageTag method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.49.6",
+  "version": "3.49.7",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/pages/__tests__/create-page-tag-test.js
+++ b/source/api/pages/__tests__/create-page-tag-test.js
@@ -1,0 +1,65 @@
+import moxios from 'moxios'
+import { instance, updateClient } from '../../../utils/client'
+import { createPageTag } from '..'
+
+describe('Create Page', () => {
+  beforeEach(() => {
+    moxios.install(instance)
+  })
+
+  afterEach(() => {
+    moxios.uninstall(instance)
+  })
+
+  describe('Create EDH Page', () => {
+    it('is not supported', () => {
+      const test = () =>
+        createPageTag({
+          slug: 'my-page',
+          id: '123',
+          label: 'Number',
+          value: '1'
+        })
+
+      expect(test).to.throw
+    })
+  })
+
+  describe('Create JG Page', () => {
+    beforeEach(() => {
+      updateClient({ baseURL: 'https://api.justgiving.com' })
+    })
+
+    afterEach(() => {
+      updateClient({ baseURL: 'https://everydayhero.com' })
+    })
+
+    it('uses the correct url to fetch pages', done => {
+      createPageTag({
+        slug: 'my-page',
+        label: 'State',
+        id: 'state',
+        value: 'Queensland',
+        aggregation: [
+          {
+            segment: 'page:campaign:1234-5678-abcd-0123',
+            measurementDomains: ['all']
+          }
+        ]
+      })
+
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent()
+        expect(request.url).to.contain(
+          'https://api.justgiving.com/v1/tags/my-page'
+        )
+        done()
+      })
+    })
+
+    it('throws if no slug is passed', () => {
+      const test = () => createPageTag({ bogus: 'data' })
+      expect(test).to.throw
+    })
+  })
+})

--- a/source/api/pages/everydayhero/index.js
+++ b/source/api/pages/everydayhero/index.js
@@ -204,3 +204,6 @@ export const updatePage = (
     target
   }).then(response => response.page)
 }
+
+export const createPageTag = () =>
+  Promise.reject(new Error('This method is not supported for everydayhero'))

--- a/source/api/pages/index.js
+++ b/source/api/pages/index.js
@@ -7,7 +7,8 @@ import {
   fetchUserPages as fetchEDHUserPages,
   fetchPageDonationCount as fetchEDHPageDonationCount,
   createPage as createEDHPage,
-  updatePage as updateEDHPage
+  updatePage as updateEDHPage,
+  createPageTag as createEDHPageTag
 } from './everydayhero'
 
 import {
@@ -17,7 +18,8 @@ import {
   fetchUserPages as fetchJGUserPages,
   fetchPageDonationCount as fetchJGPageDonationCount,
   createPage as createJGPage,
-  updatePage as updateJGPage
+  updatePage as updateJGPage,
+  createPageTag as createJGPageTag
 } from './justgiving'
 
 /**
@@ -60,3 +62,9 @@ export const createPage = params =>
  */
 export const updatePage = (pageId, params) =>
   isJustGiving() ? updateJGPage(pageId, params) : updateEDHPage(pageId, params)
+
+/**
+ * @function create page tag
+ */
+export const createPageTag = params =>
+  isJustGiving() ? createJGPageTag(params) : createEDHPageTag(params)

--- a/source/api/pages/justgiving/index.js
+++ b/source/api/pages/justgiving/index.js
@@ -4,7 +4,7 @@ import lodashGet from 'lodash/get'
 import lodashFilter from 'lodash/filter'
 import slugify from 'slugify'
 import { v4 as uuid } from 'uuid'
-import { get, put, servicesAPI } from '../../../utils/client'
+import { get, post, put, servicesAPI } from '../../../utils/client'
 import { apiImageUrl, baseUrl, imageUrl } from '../../../utils/justgiving'
 import { getUID, isEqual, required } from '../../../utils/params'
 import jsonDate from '../../../utils/jsonDate'
@@ -263,6 +263,30 @@ const truncate = (string, length = 50) => {
   }
 
   return undefined
+}
+
+export const createPageTag = ({
+  id = required(),
+  label = required(),
+  slug = required(),
+  value = required(),
+  aggregation = []
+}) => {
+  const request = () =>
+    post(
+      `/v1/tags/${slug}`,
+      {
+        aggregation,
+        id,
+        label,
+        value
+      },
+      {
+        timeout: 5000
+      }
+    )
+
+  return request().catch(() => request()) // Retry if request fails
 }
 
 export const createPage = ({

--- a/source/api/pages/readme.md
+++ b/source/api/pages/readme.md
@@ -144,7 +144,7 @@ See [the API documentation](http://developer.everydayhero.com/pages/#create-an-i
   - `value` (String) Value of Tag
   - `aggregation` (Array of Object) Settings for how tag is grouped
     - `segment` (String)
-    - `measurementDomains` (Array) Accepts fundraising:donations_received, ride:distance, walk:distance, any:distance
+    - `measurementDomains` (Array) Accepts e.g. `all`, `fundraising:donations_received`, `ride:distance`, `walk:distance`, `any:distance`
 
 **Example of tag object shape**
 ```javascript
@@ -214,5 +214,46 @@ import { updatePage } from 'supporticon/api/pages'
 updatePage(123, {
   token: 'xxxxx',
   story: 'This is an updated story'
+})
+```
+
+## `createPageTag`
+
+Create or update a Page Tag. (JG Only)
+
+**Params**
+
+- `params` (Object) Containing the following:
+  - `slug` (String) Page slug _required_
+  - `id` (String) Tag definition ID, needed for reference when filtering or creating leaderboards from tags _required_
+  - `label` (String) Tag definition label _required_
+  - `value` (String) Tag value _required_
+  - `aggregation` (Array of Objects) Settings for how tag is grouped
+    - `segment` (String)
+    - `measurementDomains` (Array) Accepts e.g. `all`, `fundraising:donations_received`, `ride:distance`, `walk:distance`, `any:distance`
+
+**Returns**
+
+A pending promise that will either resolve to:
+
+- Success: the data returned from the request
+- Failure: the error encountered
+
+**Example**
+
+```javascript
+import { createPageTag } from 'supporticon/api/pages'
+
+createPageTag({
+  slug: 'my-page',
+  label: 'State',
+  id: 'state',
+  value: 'Queensland',
+  aggregation: [
+    {
+      segment: 'page:campaign:1234-5678-abcd-0123',
+      measurementDomains: ['all']
+    }
+  ]
 })
 ```


### PR DESCRIPTION
In my tests when creating a bunch of tags at once (e.g. 4 or 5) the request sometimes inexplicably times out, but seems to work when trying again. I'm assuming this is some sort of concurrency issue, but retrying the request seems to get around it.

Also the request timeout for that endpoint was ~2 mins, hence the 5 second timeout setting here.