### PR TITLE
JG fitness API updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.49.12",
+  "version": "3.50.0",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/fitness-activities/__tests__/delete-activity-test.js
+++ b/source/api/fitness-activities/__tests__/delete-activity-test.js
@@ -1,5 +1,5 @@
 import moxios from 'moxios'
-import { instance, servicesAPI, updateClient } from '../../../utils/client'
+import { instance, updateClient } from '../../../utils/client'
 import { deleteFitnessActivity } from '..'
 
 describe('Delete Fitness Activity', () => {
@@ -49,12 +49,10 @@ describe('Delete Fitness Activity', () => {
         baseURL: 'https://api.justgiving.com',
         headers: { 'x-api-key': 'abcd1234' }
       })
-      moxios.install(servicesAPI)
     })
 
     afterEach(() => {
       updateClient({ baseURL: 'https://everydayhero.com' })
-      moxios.uninstall(servicesAPI)
     })
 
     it('throws if no token is passed', () => {
@@ -63,15 +61,22 @@ describe('Delete Fitness Activity', () => {
     })
 
     it('hits the api with the correct url and data', done => {
-      deleteFitnessActivity('3210-1234-43210', 'test-token')
+      deleteFitnessActivity({
+        id: '12345678',
+        page: 'test-page',
+        token: 'test-token'
+      })
 
       moxios.wait(() => {
         const request = moxios.requests.mostRecent()
         const headers = request.config.headers
 
         expect(request.url).to.contain(
-          'https://api.blackbaud.services/v1/justgiving/graphql'
+          'https://api.justgiving.com/v1/fitness/fundraising'
         )
+
+        expect(request.url).to.contain('test-page')
+        expect(request.url).to.contain('12345678')
         expect(headers.Authorization).to.equal('Bearer test-token')
         done()
       })

--- a/source/api/fitness-activities/everydayhero/index.js
+++ b/source/api/fitness-activities/everydayhero/index.js
@@ -132,5 +132,16 @@ export const updateFitnessActivity = (
     virtual
   })
 
-export const deleteFitnessActivity = (id = required(), token = required()) =>
-  destroy(`/api/v2/fitness_activities/${id}?access_token=${token}`)
+export function deleteFitnessActivity (params) {
+  let id, token
+
+  if (arguments.length === 1 && typeof arguments[0] === 'object') {
+    id = params.id
+    token = params.token
+  } else {
+    id = arguments[0]
+    token = arguments[1]
+  }
+
+  return destroy(`/api/v2/fitness_activities/${id}?access_token=${token}`)
+}

--- a/source/api/fitness-activities/everydayhero/index.js
+++ b/source/api/fitness-activities/everydayhero/index.js
@@ -1,7 +1,7 @@
 import moment from 'moment'
 import { v4 as uuid } from 'uuid'
 import { destroy, get, post, put } from '../../../utils/client'
-import { required } from '../../../utils/params'
+import { isParamsObject, required } from '../../../utils/params'
 import { convertToMeters, convertToSeconds } from '../../../utils/units'
 
 export const deserializeFitnessActivity = (activity = required()) => ({
@@ -135,7 +135,7 @@ export const updateFitnessActivity = (
 export function deleteFitnessActivity (params) {
   let id, token
 
-  if (arguments.length === 1 && typeof arguments[0] === 'object') {
+  if (isParamsObject(arguments)) {
     id = params.id
     token = params.token
   } else {

--- a/source/api/fitness-activities/index.js
+++ b/source/api/fitness-activities/index.js
@@ -36,7 +36,7 @@ export const updateFitnessActivity = (activityId, params) =>
     ? updateJGFitnessActivity(activityId, params)
     : updateEDHFitnessActivity(activityId, params)
 
-export const deleteFitnessActivity = (activityId, token) =>
+export const deleteFitnessActivity = (...args) =>
   isJustGiving()
-    ? deleteJGFitnessActivity(activityId, token)
-    : deleteEDHFitnessActivity(activityId, token)
+    ? deleteJGFitnessActivity(...args)
+    : deleteEDHFitnessActivity(...args)

--- a/source/api/fitness-activities/justgiving/index.js
+++ b/source/api/fitness-activities/justgiving/index.js
@@ -47,28 +47,32 @@ export const deserializeFitnessActivity = (activity = required()) => ({
 })
 
 export const fetchFitnessActivities = (params = required()) => {
-  const limit = params.limit || 1000
-  const offset = params.offset || 0
+  const query = {
+    limit: params.limit || 100,
+    offset: params.offset || 0,
+    start: params.startDate,
+    end: params.endDate
+  }
 
   if (params.page) {
-    return get(`/v1/fitness/fundraising/${params.page}`, {
-      limit,
-      offset
-    }).then(response => response.activities)
+    return get(`/v1/fitness/fundraising/${params.page}`, query).then(
+      response => response.activities
+    )
   }
 
   if (params.team) {
-    return get(`/v1/fitness/teams/${params.team}`, { limit, offset }).then(
+    return get(`/v1/fitness/teams/${params.team}`, query).then(
       response => response.activities
     )
   }
 
   if (params.campaign) {
-    const query = { campaignGuid: params.campaign, limit, offset }
-
-    return get('/v1/fitness/campaign', query, {}, { paramsSerializer }).then(
-      response => response.activities
-    )
+    return get(
+      '/v1/fitness/campaign',
+      { ...query, campaignGuid: params.campaign },
+      {},
+      { paramsSerializer }
+    ).then(response => response.activities)
   }
 
   return required()

--- a/source/api/fitness-leaderboard/justgiving/index.js
+++ b/source/api/fitness-leaderboard/justgiving/index.js
@@ -22,11 +22,21 @@ const fetchActivePages = pages => {
     )
 }
 
-export const fetchFitnessLeaderboard = (params = required()) => {
-  const { campaign = required(), activeOnly, type } = params
-
+export const fetchFitnessLeaderboard = ({
+  campaign = required(),
+  activeOnly,
+  type,
+  limit,
+  offset,
+  startDate,
+  endDate
+}) => {
   const query = {
-    campaignGuid: campaign
+    campaignGuid: campaign,
+    limit: limit || 100,
+    offset: offset || 0,
+    start: startDate,
+    end: endDate
   }
 
   return client

--- a/source/api/fitness-totals/__tests__/fitness-test.js
+++ b/source/api/fitness-totals/__tests__/fitness-test.js
@@ -35,7 +35,7 @@ describe('Fetch Fitness Totals', () => {
       })
     })
 
-    it('Only return a total of valid fitnessType(s) if requested', done => {
+    it('Only returns a total of valid fitnessType(s) if requested', done => {
       fetchFitnessTotals('au-123', ['walk', 'run', 'jog']).then(response => {
         totalsEqual(response, 115)
         done()
@@ -45,11 +45,23 @@ describe('Fetch Fitness Totals', () => {
       })
     })
 
-    it('Return default total if all supplied fitnessType(s) are invalid', done => {
+    it('Returns default total if all supplied fitnessType(s) are invalid', done => {
       fetchFitnessTotals('au-123', ['dance', 'skip']).then(response => {
         totalsEqual(response, 240)
         done()
       })
+      moxios.wait(() => {
+        moxios.requests.mostRecent().respondWith(singleCampaign)
+      })
+    })
+
+    it('Allows params to be passed as an object', done => {
+      fetchFitnessTotals({ campaign: 'au-123', types: ['dance', 'skip'] }).then(
+        response => {
+          totalsEqual(response, 240)
+          done()
+        }
+      )
       moxios.wait(() => {
         moxios.requests.mostRecent().respondWith(singleCampaign)
       })
@@ -96,6 +108,17 @@ describe('Fetch Fitness Totals', () => {
 
     it('returns the distance for the campaign', done => {
       fetchFitnessTotals('12345').then(response => {
+        expect(response.distance).to.equal(100)
+        expect(response.elevation).to.equal(50)
+        done()
+      })
+      moxios.wait(() => {
+        moxios.requests.mostRecent().respondWith(singleJGCampaign)
+      })
+    })
+
+    it('allows params to be passed as an object', done => {
+      fetchFitnessTotals({ campaign: '12345' }).then(response => {
         expect(response.distance).to.equal(100)
         expect(response.elevation).to.equal(50)
         done()

--- a/source/api/fitness-totals/everydayhero/index.js
+++ b/source/api/fitness-totals/everydayhero/index.js
@@ -1,4 +1,4 @@
-import { required } from '../../../utils/params'
+import { isParamsObject, required } from '../../../utils/params'
 import pick from 'lodash/pick'
 import isEmpty from 'lodash/isEmpty'
 import fitnessTypes from '../consts/fitness-types'
@@ -17,8 +17,22 @@ export const fetchFitnessSummary = (campaign = required(), types) =>
       .then(results => (types ? filterTypes(results, types) : results))
       .catch(err => console.log(err))
 
-export const fetchFitnessTotals = (campaign = required(), types) =>
-  fetchFitnessSummary(campaign, types)
+export function fetchFitnessTotals (params) {
+  let campaign, types
+
+  if (isParamsObject(arguments)) {
+    campaign = params.campaign
+    types = params.types
+  } else {
+    campaign = arguments[0]
+    types = arguments[1]
+  }
+
+  if (!campaign) {
+    return required()
+  }
+
+  return fetchFitnessSummary(campaign, types)
     .then(summary =>
       Object.keys(summary).reduce(
         (result, item, i) => ({
@@ -30,6 +44,7 @@ export const fetchFitnessTotals = (campaign = required(), types) =>
       )
     )
     .catch(err => console.log(err))
+}
 
 const deserializeOverview = ({ fitness_activity_overview: overview }) =>
   fitnessTypes.reduce((result, fitnessType, i) => {

--- a/source/api/fitness-totals/index.js
+++ b/source/api/fitness-totals/index.js
@@ -15,7 +15,7 @@ export const fetchFitnessSummary = (campaign, types) =>
     ? fetchJGFitnessSummary(campaign, types)
     : fetchEDHFitnessSummary(campaign, types)
 
-export const fetchFitnessTotals = (campaign, types) =>
+export const fetchFitnessTotals = (...args) =>
   isJustGiving()
-    ? fetchJGFitnessTotals(campaign, types)
-    : fetchEDHFitnessTotals(campaign, types)
+    ? fetchJGFitnessTotals(...args)
+    : fetchEDHFitnessTotals(...args)

--- a/source/api/fitness-totals/justgiving/index.js
+++ b/source/api/fitness-totals/justgiving/index.js
@@ -1,12 +1,30 @@
 import * as client from '../../../utils/client'
-import { paramsSerializer, required } from '../../../utils/params'
+import {
+  isParamsObject,
+  paramsSerializer,
+  required
+} from '../../../utils/params'
 
 export const fetchFitnessSummary = (campaign = required(), types) =>
   Promise.reject(new Error('This method is not supported for JustGiving'))
 
-export const fetchFitnessTotals = (campaign = required()) => {
-  const query = {
-    campaignGuid: campaign
+export function fetchFitnessTotals (params) {
+  let query = {}
+
+  if (isParamsObject(arguments)) {
+    query = {
+      campaignGuid: params.campaign,
+      limit: params.limit || 100,
+      offset: params.offset || 0,
+      start: params.startDate,
+      end: params.endDate
+    }
+  } else {
+    query = { campaignGuid: arguments[0] }
+  }
+
+  if (!query.campaignGuid) {
+    return required()
   }
 
   return client

--- a/source/api/pages/justgiving/index.js
+++ b/source/api/pages/justgiving/index.js
@@ -226,7 +226,7 @@ export const fetchPage = (page = required(), slug, options = {}) => {
 
   const fetchers = [
     get(`/v1/fundraising/${endpoint}/${page}`),
-    options.includeFitness && fetchPageFitness(page),
+    options.includeFitness && fetchPageFitness(page, options.fitnessParams),
     options.includeTags && fetchPageTags(page)
   ]
 
@@ -269,8 +269,15 @@ export const fetchPageTags = page => {
   return get(`v1/tags/${page}`)
 }
 
-const fetchPageFitness = page => {
-  return get(`/v1/fitness/fundraising/${page}`)
+const fetchPageFitness = (page, params = {}) => {
+  const query = {
+    limit: params.limit || 100,
+    offset: params.offset || 0,
+    start: params.startDate,
+    end: params.endDate
+  }
+
+  return get(`/v1/fitness/fundraising/${page}`, query)
 }
 
 export const fetchPageDonationCount = (page = required()) => {

--- a/source/components/fitness-progress-bar/index.js
+++ b/source/components/fitness-progress-bar/index.js
@@ -31,8 +31,14 @@ class FitnessProgressBar extends Component {
   }
 
   fetchData () {
-    const { campaign, fitnessTypes } = this.props
-    fetchFitnessTotals(campaign, fitnessTypes)
+    const { campaign, fitnessTypes, startDate, endDate } = this.props
+
+    fetchFitnessTotals({
+      campaign,
+      startDate,
+      endDate,
+      types: fitnessTypes
+    })
       .then(({ distance }) => this.setState({ status: 'fetched', distance }))
       .catch(() => this.setState({ status: 'failed' }))
   }
@@ -185,6 +191,16 @@ FitnessProgressBar.propTypes = {
    * Props to be passed to the Constructicon ProgressBar component
    */
   progressBar: PropTypes.object,
+
+  /**
+   * Start date filter (ISO Format)
+   */
+  startDate: PropTypes.string,
+
+  /**
+   * End date filter (ISO Format)
+   */
+  endDate: PropTypes.string,
 
   /**
    * Interval (in milliseconds) to refresh data from API

--- a/source/components/total-distance/index.js
+++ b/source/components/total-distance/index.js
@@ -27,9 +27,14 @@ class TotalDistance extends Component {
   }
 
   fetchData () {
-    const { activity, campaign } = this.props
+    const { activity, campaign, startDate, endDate } = this.props
 
-    fetchFitnessTotals(campaign, activity)
+    fetchFitnessTotals({
+      campaign,
+      startDate,
+      endDate,
+      types: activity
+    })
       .then(totals =>
         this.setState({ status: 'fetched', data: totals.distance })
       )
@@ -111,6 +116,16 @@ TotalDistance.propTypes = {
    * Include distance units?
    */
   units: PropTypes.bool,
+
+  /**
+   * Start date filter (ISO Format)
+   */
+  startDate: PropTypes.string,
+
+  /**
+   * End date filter (ISO Format)
+   */
+  endDate: PropTypes.string,
 
   /**
    * The icon to use

--- a/source/components/total-duration/index.js
+++ b/source/components/total-duration/index.js
@@ -27,9 +27,14 @@ class TotalDuration extends Component {
   }
 
   fetchData () {
-    const { activity, campaign } = this.props
+    const { activity, campaign, startDate, endDate } = this.props
 
-    fetchFitnessTotals(campaign, activity)
+    fetchFitnessTotals({
+      campaign,
+      startDate,
+      endDate,
+      types: activity
+    })
       .then(totals =>
         this.setState({ status: 'fetched', data: totals.duration })
       )
@@ -121,6 +126,16 @@ TotalDuration.propTypes = {
    * Include time units?
    */
   units: PropTypes.bool,
+
+  /**
+   * Start date filter (ISO Format)
+   */
+  startDate: PropTypes.string,
+
+  /**
+   * End date filter (ISO Format)
+   */
+  endDate: PropTypes.string,
 
   /**
    * Interval (in milliseconds) to refresh data from API

--- a/source/components/total-elevation/index.js
+++ b/source/components/total-elevation/index.js
@@ -56,9 +56,11 @@ class TotalElevation extends Component {
   }
 
   fetchJGElevation () {
-    const { campaign } = this.props
+    const { campaign, startDate, endDate } = this.props
 
-    return fetchFitnessTotals(campaign).then(totals => totals.elevation)
+    return fetchFitnessTotals({ campaign, startDate, endDate }).then(
+      totals => totals.elevation
+    )
   }
 
   calculateTotal (data) {
@@ -142,6 +144,16 @@ TotalElevation.propTypes = {
    * Include elevation units?
    */
   units: PropTypes.bool,
+
+  /**
+   * Start date filter (ISO Format)
+   */
+  startDate: PropTypes.string,
+
+  /**
+   * End date filter (ISO Format)
+   */
+  endDate: PropTypes.string,
 
   /**
    * The icon to use

--- a/source/utils/params/index.js
+++ b/source/utils/params/index.js
@@ -80,3 +80,9 @@ export const parseUrlParams = () => {
     return params
   }, {})
 }
+
+export const isParamsObject = args => {
+  return (
+    args.length === 1 && typeof args[0] === 'object' && !Array.isArray(args[0])
+  )
+}


### PR DESCRIPTION
- Delete JG fitness activities
  - Updates EDH `deleteFitnessActivity` method to be able to take the same params as JG, but includes backwards compatibility
- Handle filtering JG fitness activities, leaderboards & totals by date range
- `limit` param for fitness methods now also extends to leaderboards (pages and teams), but offset is still only for fitness activities