### PR TITLE
JG API updates

### DIFF
--- a/source/api/fitness-leaderboard/justgiving/index.js
+++ b/source/api/fitness-leaderboard/justgiving/index.js
@@ -1,6 +1,5 @@
-import chunk from 'lodash/chunk'
-import flattenDeep from 'lodash/flattenDeep'
 import get from 'lodash/get'
+import { fetchPages } from '../../pages'
 import * as client from '../../../utils/client'
 import { paramsSerializer, required } from '../../../utils/params'
 import { baseUrl, imageUrl } from '../../../utils/justgiving'
@@ -12,17 +11,7 @@ const fetchActivePages = pages => {
     return pages
   }
 
-  return Promise.all(
-    chunk(pageGuids, 20).map(guids =>
-      client.servicesAPI
-        .get('/v1/justgiving/proxy/fundraising/v2/pages/bulk', {
-          params: { pageGuids: guids.join(',') }
-        })
-        .then(response => response.data.results)
-    )
-  )
-    .then(results => flattenDeep(results))
-    .then(results => results.filter(page => page.status === 'Active'))
+  return fetchPages({ ids: pageGuids, allPages: true })
     .then(results => results.map(page => page.pageGuid))
     .then(activePageIds =>
       pages.filter(page => activePageIds.indexOf(page.ID) > -1)

--- a/source/api/leaderboard/__tests__/fetch-test.js
+++ b/source/api/leaderboard/__tests__/fetch-test.js
@@ -161,7 +161,7 @@ describe('Fetch Leaderboards', () => {
       moxios.wait(() => {
         const request = moxios.requests.mostRecent()
         expect(request.url).to.contain(
-          'https://api.blackbaud.services/v1/justgiving/campaigns/my-campaign/leaderboard'
+          'https://api.blackbaud.services/v1/justgiving/campaigns/my-campaign/pages'
         )
         done()
       })

--- a/source/components/leaderboard/index.js
+++ b/source/components/leaderboard/index.js
@@ -70,7 +70,7 @@ class Leaderboard extends Component {
 
     return fetchPages({
       allPages: true,
-      ids: data.map(page => page.pageShortName)
+      ids: data.map(page => page.pageGuid)
     })
       .then(pages => pages.map(deserializePage))
       .then(pages =>

--- a/source/components/leaderboard/index.js
+++ b/source/components/leaderboard/index.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react'
-import find from 'lodash/find'
 import orderBy from 'lodash/orderBy'
 import PropTypes from 'prop-types'
 import numbro from 'numbro'
@@ -15,7 +14,6 @@ import RichText from 'constructicon/rich-text'
 import Section from 'constructicon/section'
 
 import { fetchLeaderboard, deserializeLeaderboard } from '../../api/leaderboard'
-import { fetchPages, deserializePage } from '../../api/pages'
 
 class Leaderboard extends Component {
   constructor () {
@@ -63,29 +61,6 @@ class Leaderboard extends Component {
       const excluded = Array.isArray(values) ? values : values.split(',')
       return excluded.indexOf(item.group.value.toString()) === -1
     })
-  }
-
-  fetchOfflinePages (data) {
-    if (!isJustGiving()) return data
-
-    return fetchPages({
-      allPages: true,
-      ids: data.map(page => page.pageGuid)
-    })
-      .then(pages => pages.map(deserializePage))
-      .then(pages =>
-        data.map(page => {
-          const pageData =
-            find(pages, ({ slug }) => slug === page.pageShortName) || {}
-
-          return {
-            ...page,
-            amount: page.amount || pageData.raised,
-            defaultImage: pageData.image,
-            name: pageData.name
-          }
-        })
-      )
   }
 
   handleData (data, excludeOffline, deserializeMethod, limit) {
@@ -154,12 +129,6 @@ class Leaderboard extends Component {
         data =>
           type === 'group'
             ? this.removeExcludedGroups(data, excludePageIds)
-            : data
-      )
-      .then(
-        data =>
-          isJustGiving() && !excludeOffline && allPages
-            ? this.fetchOfflinePages(data)
             : data
       )
       .then(data => {

--- a/source/utils/params/index.js
+++ b/source/utils/params/index.js
@@ -61,6 +61,11 @@ export const isURL = str => {
   return urlRegex.test(str)
 }
 
+export const isUuid = string => {
+  const uuidRegex = /^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-5][0-9a-f]{3}-?[089ab][0-9a-f]{3}-?[0-9a-f]{12}$/i
+  return uuidRegex.test(string)
+}
+
 export const isEqual = (a, b) => String(a) === String(b)
 
 export const parseUrlParams = () => {


### PR DESCRIPTION
- Recursively fetch leaderboard per 20 pages to avoid errors
- Use v2 pages endpoint for leaderboard method
- Move chunked bulk fetching to main fetchPages method where applicable
- Remove API call that is no longer needed