### PR TITLE
Leaderboard deserializer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.51.0",
+  "version": "3.51.1",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/leaderboard/justgiving/index.js
+++ b/source/api/leaderboard/justgiving/index.js
@@ -206,10 +206,10 @@ export const deserializeLeaderboard = (supporter, index) => {
     owner: owner || supporter.owner,
     position: index + 1,
     raised: parseFloat(
-      supporter.amount ||
+      supporter.donationAmount ||
+        supporter.amount ||
         supporter.raisedAmount ||
         supporter.amountRaised ||
-        supporter.donationAmount ||
         0
     ),
     slug,


### PR DESCRIPTION
Issue popped up in GSK with deserializing leaderboards from JG. We want to default to donationAmount if it exists, since amountRaised is actually pulled from the page. 

For instance, If we set a leaderboard request to use GBP currency but the page is set to USD then by using amountRaised we are showing the amount in USD and not GBP. By using donationAmount we can ensure we supply the amount in the currency requested.

This page demonstrates the issue. The second item in the leaderboard is showing the wrong  currency total:
https://uk.gsk-stcfundraising.com/trek-for-kids