### PR TITLE
Use isAvailable endpoint to check of team slug is available

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.51.0",
+  "version": "3.51.1",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/teams/__tests__/create-team--test.js
+++ b/source/api/teams/__tests__/create-team--test.js
@@ -69,10 +69,13 @@ describe('Create a Team', () => {
       moxios.wait(() => {
         const shortNameRequest = moxios.requests.mostRecent()
 
-        shortNameRequest.respondWith({ status: 404 })
+        shortNameRequest.respondWith({
+          status: 200,
+          response: { isAvailable: true }
+        })
 
         expect(shortNameRequest.url).to.contain(
-          'https://api.blackbaud.services/v1/justgiving/proxy/campaigns/v1/teams/by-short-name/my-team/full'
+          'https://api.blackbaud.services/v1/justgiving/proxy/campaigns/v1/teams/shortNames/my-team/isAvailable'
         )
 
         moxios.wait(() => {


### PR DESCRIPTION
This is to solve Kerri's issue in virtual. Problem was `fetchTeamBySlug` was returning a 404 for team pages that existed, but had been archived, giving us the false impression that the slug was available. The subsequent request to create the page was obviously failing.

I was going to retry with a unique slug if this happened, but I had a poke around and found this `isAvailable` endpoint for teams, that does what we need. Basically, we check if the team slug `isAvailable`, and append a uuid if either it is not available or as a fallback if the request fails for whatever reason.

I tested this locally and it works as expected for all team pages, including Kerri's archived one that was causing us issues earlier. Interestingly, it does require auth, but that's ok as we have it there to ready to go to create the page anyway.