### PR TITLE
Fetch all teams

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.51.4",
+  "version": "3.51.5",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This might be bit of an edge case, but for larger campaigns we may want a way to fetch all teams up front. Adding a new param similar to pages methods (called allTeams) to indicate we want to get all teams up front and recursively fetch to accomplish this. My use case right now is for Team Search for ARUK. Perhaps we will want to use Onesearch for these in the future, but I have had mixed results with that and I don't think it supports teams yet (could be wrong there).

In addition, I see we are running our teams request through the Services API Proxy endpoint, is this because of some CORS issues with the teams endpoints? The teams search method does return a next property, which makes things a bit easier for for sorting out the recursive fetch (compared to what we have to do with allPages), but we could just use the next url for our next request if we were using the JG API endpoint. Might make it a bit cleaner, open to suggestions there or just leave as is.

Quick video showing this when fetching allTeams one at a time in a test campaign (that has 4 teams):
https://drive.google.com/file/d/1rnwYLmjYcxBH85DKsxl69vKcjf_uC9Fp/view
On the last call we get null returned from the next prop and we stop the loop and return our results.