### PR TITLE
force manualAddress if JG and not in UK

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.51.6",
+  "version": "3.51.7",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/components/create-page-form/index.js
+++ b/source/components/create-page-form/index.js
@@ -40,7 +40,7 @@ class CreatePageForm extends Component {
   }
 
   componentDidMount () {
-    if (isJustGiving && this.props.country !== 'uk') {
+    if (isJustGiving() && this.props.country !== 'uk') {
       this.setState({ manualAddress: true })
     }
   }

--- a/source/components/create-page-form/index.js
+++ b/source/components/create-page-form/index.js
@@ -39,6 +39,12 @@ class CreatePageForm extends Component {
     }
   }
 
+  componentDidMount () {
+    if (isJustGiving && this.props.country !== 'uk') {
+      this.setState({ manualAddress: true })
+    }
+  }
+
   handleSubmit (e) {
     e.preventDefault()
 


### PR DESCRIPTION
Issue called out by Kerri Mercer where in SiteBuilder the address search does not work if JG client and not in UK. Adding quick fix for this, where the createPageForm sets the address render to manualAddress if its JG and not in UK. This is a workaround that at least allows US clients to collect address. We may want to visit opening up address search to non-UK clients using JG SiteBuilder since we do have a GoogleMaps solution built in Supporticon. Perhaps that is custom reg situation that is iframed in since that could incur costs.