### PR TITLE
Support elevation for JG/EDH pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.51.7",
+  "version": "3.52.0",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/pages/justgiving/index.js
+++ b/source/api/pages/justgiving/index.js
@@ -66,6 +66,7 @@ export const deserializePage = page => {
     fitnessGoal: parseInt(page.pageSummaryWhat) || 0,
     fitnessDistanceTotal: lodashGet(page, 'fitness.totalAmount', 0),
     fitnessDurationTotal: lodashGet(page, 'fitness.totalAmountTaken', 0),
+    fitnessElevationTotal: lodashGet(page, 'fitness.totalAmountElevation', 0),
     groups: null,
     hasUpdatedImage:
       page.imageCount &&


### PR DESCRIPTION
* JG already includes `totalAmountElevation` when `options.includeFitness` is set, so we just need to add that to deserializer
* EDH page response only includes distance and duration, so we have to make an extra request to fetch the elevation