### PR TITLE
Handle resizing images in create post form

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.53.1",
+  "version": "3.53.2",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "babel-preset-stage-0": "^6.22.0",
     "babel-register": "^6.22.0",
     "chai": "^3.5.0",
-    "constructicon": "^2.7.2",
+    "constructicon": "^2.8.7",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
     "eslint": "^5.6.0",

--- a/source/components/create-post-form/index.js
+++ b/source/components/create-post-form/index.js
@@ -16,14 +16,16 @@ import InputVideo from 'constructicon/input-video'
 import Section from 'constructicon/section'
 
 class CreatePostForm extends React.Component {
-  constructor () {
-    super()
+  constructor (props) {
+    super(props)
     this.handleSubmit = this.handleSubmit.bind(this)
     this.state = {
       errors: [],
+      height: props.height,
       image: null,
       status: null,
-      video: null
+      video: null,
+      width: props.width
     }
   }
 
@@ -53,10 +55,10 @@ class CreatePostForm extends React.Component {
   }
 
   handleChangeAttachment (val, field = 'image') {
-    const { form } = this.props
+    const { form, height, resizeOnUpload, width } = this.props
 
     if (!val) {
-      this.setState({ [field]: null })
+      this.setState({ [field]: null, width, height })
       return form.fields[field].onChange('')
     }
 
@@ -64,13 +66,29 @@ class CreatePostForm extends React.Component {
       case 'object':
         return this.setState({ [field]: val })
       default:
+        if (resizeOnUpload && field === 'image') {
+          const image = new window.Image()
+          image.src = val
+          image.onload = () => {
+            this.setState({ width: image.width, height: image.height })
+          }
+        }
+
         return form.fields[field].onChange(val)
     }
   }
 
   render () {
-    const { errors, image, status, video } = this.state
-    const { buttonProps, form, formProps, inputProps, submit } = this.props
+    const { errors, height, image, status, video, width } = this.state
+    const {
+      buttonProps,
+      form,
+      formProps,
+      inputProps,
+      orientationChange,
+      resizeOnUpload,
+      submit
+    } = this.props
 
     return (
       <Form
@@ -94,8 +112,10 @@ class CreatePostForm extends React.Component {
                 <InputImage
                   {...inputProps}
                   {...form.fields.image}
-                  width={1200}
-                  height={900}
+                  orientationChange={orientationChange}
+                  resizeOnUpload={resizeOnUpload}
+                  width={width}
+                  height={height}
                   onChange={val => this.handleChangeAttachment(val, 'image')}
                   onFileChange={val =>
                     this.handleChangeAttachment(val, 'image')
@@ -128,8 +148,12 @@ class CreatePostForm extends React.Component {
 }
 
 CreatePostForm.defaultProps = {
+  height: 900,
   onSuccess: () => {},
-  submit: 'Post Update'
+  orientationChange: true,
+  resizeOnUpload: true,
+  submit: 'Post Update',
+  width: 1200
 }
 
 CreatePostForm.propTypes = {
@@ -147,6 +171,11 @@ CreatePostForm.propTypes = {
    * Props to be passed to the Form component
    */
   formProps: PropTypes.object,
+
+  /**
+   * Image height in pixels
+   */
+  height: PropTypes.number,
 
   /**
    * Props to be passed to the Input components
@@ -176,7 +205,12 @@ CreatePostForm.propTypes = {
   /**
    * The page owner id (required for JG)
    */
-  userId: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  userId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+
+  /**
+   * Image width in pixels
+   */
+  width: PropTypes.number
 }
 
 export default withForm(form)(CreatePostForm)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2266,10 +2266,10 @@ constants-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
 
-constructicon@^2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/constructicon/-/constructicon-2.7.2.tgz#87dfbe24c65331f135ad32dd2aa500f0f4acb6e8"
-  integrity sha512-Ziqd65tfQE/l7v5NTiIKygSkTb7hz9DyIbu8YtGAgg/WwegLaaNJgGNNtfRORz1ZqVpgvuLs8V+HViEoRsiGXA==
+constructicon@^2.8.7:
+  version "2.8.7"
+  resolved "https://registry.yarnpkg.com/constructicon/-/constructicon-2.8.7.tgz#51ba3bc347c80215471bdc0e38c280dbaef927e7"
+  integrity sha512-hsvkHPbxqO+o2h11N1u9EIKQ6v3HMgpswiayiQ9eWmUDjd++yvPmd2vtgf9iKE6aaaLo27KFZjDr1tssS+UmGg==
   dependencies:
     axios "^0.19.2"
     emotion "^9.2.7"
@@ -2286,6 +2286,7 @@ constructicon@^2.7.2:
     react-onclickoutside "^6.9.0"
     react-slick "^0.26.1"
     react-slider "^1.0.7"
+    react-ticker "^1.2.2"
     sanitize-html "^1.24.0"
 
 content-disposition@0.5.2:
@@ -8505,6 +8506,11 @@ react-test-renderer@^16.0.0-0:
     fbjs "^0.8.16"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
+
+react-ticker@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/react-ticker/-/react-ticker-1.2.2.tgz#12cda5ff8266c6fe90ffcd8c58e12ba1596ddf24"
+  integrity sha512-PXUujoPJvajxwOfosuuujlrBUrjgGp4FB4haWFOI25ujhMppW4SuLkiOdQ9AylrWN3yTHWdk2kbQWe3n9SjFGA==
 
 react@^16.13.1:
   version "16.13.1"


### PR DESCRIPTION
As the `ImageInput` component is within a modal, it gets re-rendered every time the image modal is opened/closed, hence why we need to also handle resizing the canvas here as well as c11n.

![2020-08-25 13-47-09 2020-08-25 13_48_39](https://user-images.githubusercontent.com/729085/91120834-e3102800-e6d9-11ea-860a-9262a0d131c1.gif)
