### PR TITLE
Build donation url

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.53.4",
+  "version": "3.53.5",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/donations/justgiving/index.js
+++ b/source/api/donations/justgiving/index.js
@@ -1,6 +1,8 @@
 import { get } from '../../../utils/client'
 import { required } from '../../../utils/params'
 import jsonDate from '../../../utils/jsonDate'
+import numbro from 'numbro'
+import { stringify } from 'querystringify'
 
 export const fetchDonation = (id = required()) => get(`/v1/donation/${id}`)
 
@@ -23,3 +25,23 @@ export const deserializeDonation = donation => ({
   status: donation.status,
   id: donation.id
 })
+
+export const buildDonationUrl = ({
+  amount = required(),
+  slug,
+  id,
+  currency = 'GBP',
+  ...args
+}) => {
+  const baseUrl = process.env.SUPPORTICON_BASE_URL.replace('api', 'link')
+  const params = stringify({
+    amount: numbro(amount).format('0.00'),
+    currency,
+    ...args
+  })
+  if (slug || id) {
+    return id
+      ? `${baseUrl}/v1/fundraisingpage/donate/pageId/${id}?${params}`
+      : `${baseUrl}/v1/fundraising/${slug}/donate?${params}`
+  }
+}

--- a/source/api/donations/readme.md
+++ b/source/api/donations/readme.md
@@ -31,6 +31,37 @@ import { fetchDonation } from 'supporticon/api/donations'
 fetchDonation('12345')
 ```
 
+## `buildDonationUrl`
+
+**Purpose**
+
+Create donation URL link for fundraiser. Can set with either page slug or page id. (JG only)
+
+**Params**
+
+- `amount` - pre-selected donation amount when donation form loaded (number)
+- `slug` - Page slug (string)
+- `id` - Page Id (string)
+- `reference` - donation reference to be applied to succesful donations (string)
+- `exitUrl` - a redirect link for successful transactions, can pass back donation transaction in formation by using *JUST_GIVING_DONATION_ID* (string)
+
+**Returns**
+
+Formatted JustGiving donation url for fundraiser
+
+**Example**
+
+```javascript
+import { buildDonationUrl } from 'supporticon/api/donations/justgiving'
+
+buildDonationUrl({
+  amount: 50,
+  slug: 'test-page' ,
+  reference: 'self-donate',
+  exitUrl: `${process.env.APPLICATION_URL}/thank-you/JUSTGIVING-DONATION-ID`
+})
+```
+
 
 ## `replyToDonation`
 


### PR DESCRIPTION
Often need to create custom donation url with params for donation reference (ie for self donor) or redirect links back to the app after successful transaction. Figured it would make sense to have this in Supporticon rather than individual projects going forward.