### PR TITLE
Fetch correct campaign totals including page offline amounts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.53.5",
+  "version": "3.53.6",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/donation-totals/__tests__/totals-test.js
+++ b/source/api/donation-totals/__tests__/totals-test.js
@@ -96,12 +96,17 @@ describe('Fetch Donation Totals', () => {
       })
     })
 
-    it('uses the correct url to fetch totals for a campaign', done => {
-      fetchJGDonationTotals({ campaign: 'my-campaign' })
+    it('uses the correct urls to fetch totals for a campaign (with offline amounts)', done => {
+      fetchJGDonationTotals({ campaign: 'my-campaign', includeOffline: true })
       moxios.wait(() => {
-        const request = moxios.requests.mostRecent()
-        expect(request.url).to.equal(
+        const firstRequest = moxios.requests.at(0)
+        const secondRequest = moxios.requests.at(1)
+
+        expect(firstRequest.url).to.equal(
           'https://api.blackbaud.services/v1/justgiving/campaigns/my-campaign'
+        )
+        expect(secondRequest.url).to.equal(
+          'https://api.blackbaud.services/v1/justgiving/campaigns/my-campaign/pages'
         )
         done()
       })

--- a/source/api/donation-totals/justgiving/index.js
+++ b/source/api/donation-totals/justgiving/index.js
@@ -1,4 +1,4 @@
-import client from '../../../utils/client'
+import client, { servicesAPI } from '../../../utils/client'
 import get from 'lodash/get'
 import {
   getUID,
@@ -6,9 +6,32 @@ import {
   dataSource,
   paramsSerializer
 } from '../../../utils/params'
-import { fetchCampaign } from '../../campaigns'
 import { fetchDonations } from '../../feeds/justgiving'
 import { currencyCode } from '../../../utils/currencies'
+
+const fetchCampaignTotals = id =>
+  Promise.all([
+    servicesAPI
+      .get(`/v1/justgiving/campaigns/${id}`)
+      .then(response => response.data.donationSummary),
+    servicesAPI
+      .get(`/v1/justgiving/campaigns/${id}/pages`)
+      .then(response => response.data.meta.totalAmount)
+  ]).then(([{ offlineAmount, totalNumberOfDonations }, totalAmount]) => ({
+    totalRaised: totalAmount + offlineAmount,
+    totalResults: totalNumberOfDonations
+  }))
+
+const fetchAllCampaignTotals = campaignIds =>
+  Promise.all(campaignIds.map(fetchCampaignTotals)).then(campaigns =>
+    campaigns.reduce(
+      (acc, { totalRaised, totalResults }) => ({
+        totalRaised: acc.totalRaised + totalRaised,
+        totalResults: acc.totalResults + totalResults
+      }),
+      { totalRaised: 0, totalResults: 0 }
+    )
+  )
 
 export const fetchDonationTotals = (params = required()) => {
   switch (dataSource(params)) {
@@ -43,39 +66,21 @@ export const fetchDonationTotals = (params = required()) => {
         { paramsSerializer }
       )
     default:
-      const mapTotals = data => ({
-        ...data,
-        totalRaised:
-          data.donationSummary.totalAmount - data.donationSummary.totalGiftAid,
-        totalResults: data.donationSummary.totalNumberOfDonations
-      })
+      const campaignGuids = Array.isArray(params.campaign)
+        ? params.campaign.map(getUID)
+        : [getUID(params.campaign)]
 
-      const fetchAllCampaignTotals = campaignIds =>
-        Promise.all(campaignIds.map(fetchCampaign))
-          .then(campaigns => campaigns.map(mapTotals))
-          .then(campaigns =>
-            campaigns.reduce(
-              (acc, { totalRaised, totalResults }) => ({
-                totalRaised: acc.totalRaised + totalRaised,
-                totalResults: acc.totalResults + totalResults
-              }),
-              { totalRaised: 0, totalResults: 0 }
-            )
-          )
-
-      return Array.isArray(params.campaign)
-        ? params.includeOffline
-          ? fetchAllCampaignTotals(params.campaign.map(getUID))
-          : client.get(
-            'donationsleaderboards/v1/totals',
-            {
-              campaignGuids: params.campaign.map(getUID),
-              currencyCode: currencyCode(params.country)
-            },
-            {},
-            { paramsSerializer }
-          )
-        : fetchCampaign(getUID(params.campaign)).then(mapTotals)
+      return params.includeOffline
+        ? fetchAllCampaignTotals(campaignGuids)
+        : client.get(
+          'donationsleaderboards/v1/totals',
+          {
+            campaignGuids,
+            currencyCode: currencyCode(params.country)
+          },
+          {},
+          { paramsSerializer }
+        )
   }
 }
 


### PR DESCRIPTION
So it turns out that the `/campaigns/v2/campaign/:guid` endpoint doesn't include page offline amounts in the total. `/fundraising/v2/pages?campaignGuid=:guid&includeTotalAmounts=true` does, but it doesn't factor in campaign offline amount (added by the charity), so to get a true total including all offline amounts we need to fetch both and add the correct values together.

The `donationsleaderboards/v1/totals` endpoint doesn't factor in offline amounts at all. To be honest I think we should retire that one altogether at some point.