### PR TITLE
Improve accessibility of amounts on metrics and leaderboards

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "3.53.10",
+  "version": "3.53.11",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/components/fitness-leaderboard/index.js
+++ b/source/components/fitness-leaderboard/index.js
@@ -204,6 +204,7 @@ class FitnessLeaderboard extends Component {
         subtitle={subtitleMethod(leader)}
         image={leader.image}
         amount={this.getMetric(leader)}
+        amountLabel={this.getMetricLabel(leader)}
         href={leader.url}
         rank={leader.position}
         {...leaderboardItem}
@@ -227,6 +228,30 @@ class FitnessLeaderboard extends Component {
         const distance = (offset + leader.distance) * multiplier
         return units
           ? formatDistance(distance, miles)
+          : numbro(distance).format('0,0')
+    }
+  }
+
+  getMetricLabel (leader) {
+    const { miles, multiplier, offset, sortBy, units } = this.props
+
+    switch (sortBy) {
+      case 'calories':
+        return `${numbro((offset + leader.calories) * multiplier).format(
+          '0,0'
+        )} calories`
+      case 'duration':
+        return formatDuration((offset + leader.duration) * multiplier, 'full')
+      case 'elevation':
+        return formatElevation(
+          (offset + leader.elevation) * multiplier,
+          miles,
+          'full'
+        )
+      default:
+        const distance = (offset + leader.distance) * multiplier
+        return units
+          ? formatDistance(distance, miles, 'full')
           : numbro(distance).format('0,0')
     }
   }

--- a/source/components/total-distance/index.js
+++ b/source/components/total-distance/index.js
@@ -52,6 +52,7 @@ class TotalDistance extends Component {
         icon={icon}
         label={label}
         amount={this.renderAmount()}
+        amountLabel={this.renderAmountLabel()}
         {...metric}
       />
     )
@@ -70,6 +71,23 @@ class TotalDistance extends Component {
       default:
         return units
           ? formatDistance(amount, miles)
+          : numbro(amount).format(format)
+    }
+  }
+
+  renderAmountLabel () {
+    const { status, data } = this.state
+    const { format, miles, multiplier, offset, units } = this.props
+    const amount = (offset + data) * multiplier
+
+    switch (status) {
+      case 'fetching':
+        return 'Loading'
+      case 'failed':
+        return 'Error'
+      default:
+        return units
+          ? formatDistance(amount, miles, 'full')
           : numbro(amount).format(format)
     }
   }

--- a/source/components/total-duration/index.js
+++ b/source/components/total-duration/index.js
@@ -52,6 +52,7 @@ class TotalDuration extends Component {
         icon={icon}
         label={label}
         amount={this.renderAmount()}
+        amountLabel={this.renderAmountLabel()}
         {...metric}
       />
     )
@@ -69,6 +70,23 @@ class TotalDuration extends Component {
         return <Icon name='warning' />
       default:
         return units ? formatDuration(amount) : numbro(amount).format(format)
+    }
+  }
+
+  renderAmountLabel () {
+    const { status, data } = this.state
+    const { format, multiplier, offset, units } = this.props
+    const amount = (offset + data) * multiplier
+
+    switch (status) {
+      case 'fetching':
+        return 'Loading'
+      case 'failed':
+        return 'Error'
+      default:
+        return units
+          ? formatDuration(amount, 'full')
+          : numbro(amount).format(format)
     }
   }
 }

--- a/source/components/total-elevation/index.js
+++ b/source/components/total-elevation/index.js
@@ -75,6 +75,7 @@ class TotalElevation extends Component {
         icon={icon}
         label={label}
         amount={this.renderAmount()}
+        amountLabel={this.renderAmountLabel()}
         {...metric}
       />
     )
@@ -93,6 +94,23 @@ class TotalElevation extends Component {
       default:
         return units
           ? formatElevation(amount, miles)
+          : numbro(amount).format(format)
+    }
+  }
+
+  renderAmountLabel () {
+    const { status, data } = this.state
+    const { format, miles, multiplier, offset, units } = this.props
+    const amount = (offset + data) * multiplier
+
+    switch (status) {
+      case 'fetching':
+        return 'Loading'
+      case 'failed':
+        return 'Error'
+      default:
+        return units
+          ? formatElevation(amount, miles, 'full')
           : numbro(amount).format(format)
     }
   }

--- a/source/utils/fitness/index.js
+++ b/source/utils/fitness/index.js
@@ -3,37 +3,55 @@ import moment from 'moment'
 import get from 'lodash/get'
 import * as units from '../units'
 
-export const formatDistance = (distance, miles) => {
+const labels = {
+  kilometers: { abbreviation: 'km', full: 'kilometers' },
+  miles: { abbreviation: 'mi', full: 'miles' },
+  feet: { abbreviation: 'ft', full: 'feet' },
+  days: { abbreviation: 'd', full: 'days' },
+  hours: { abbreviation: 'h', full: 'hours' },
+  minutes: { abbreviation: 'm', full: 'minutes' },
+  seconds: { abbreviation: 's', full: 'seconds' },
+  meters: { abbreviation: 'm', full: 'meters' }
+}
+
+export const formatDistance = (distance, miles, label = 'abbreviation') => {
   if (miles) {
     return (
-      numbro(units.convertMetersToMiles(distance)).format('0,0[.]0') + ' mi'
+      numbro(units.convertMetersToMiles(distance)).format('0,0[.]0') +
+      ` ${labels.miles[label]}`
     )
   } else {
-    return numbro(units.convertMetersToKm(distance)).format('0,0[.]0') + ' km'
+    return (
+      numbro(units.convertMetersToKm(distance)).format('0,0[.]0') +
+      ` ${labels.kilometers[label]}`
+    )
   }
 }
 
-export const formatDuration = duration => {
+export const formatDuration = (duration, label = 'abbreviation') => {
   if (duration >= 86400) {
-    return `${Math.floor(
-      moment.duration(duration, 'seconds').asDays()
-    )}d ${moment.duration(duration, 'seconds').hours()}h`
+    return `${Math.floor(moment.duration(duration, 'seconds').asDays())}${
+      labels.days[label]
+    } ${moment.duration(duration, 'seconds').hours()}${labels.hours[label]}`
   } else if (duration >= 3600) {
-    return `${moment.duration(duration, 'seconds').hours()}h ${moment
-      .duration(duration, 'seconds')
-      .minutes()}m`
+    return `${moment.duration(duration, 'seconds').hours()}${
+      labels.hours[label]
+    } ${moment.duration(duration, 'seconds').minutes()}${labels.minutes[label]}`
   } else {
-    return `${moment
-      .duration(duration, 'seconds')
-      .minutes()}m ${moment.duration(duration, 'seconds').seconds()}s`
+    return `${moment.duration(duration, 'seconds').minutes()}${
+      labels.minutes[label]
+    } ${moment.duration(duration, 'seconds').seconds()}${labels.seconds[label]}`
   }
 }
 
-export const formatElevation = (elevation, miles) => {
+export const formatElevation = (elevation, miles, label = 'abbreviation') => {
   if (miles) {
-    return numbro(units.convertMetersToFeet(elevation)).format('0,0') + ' ft'
+    return (
+      numbro(units.convertMetersToFeet(elevation)).format('0,0') +
+      ` ${labels.feet[label]}`
+    )
   } else {
-    return numbro(elevation).format('0,0') + ' m'
+    return numbro(elevation).format('0,0') + ` ${labels.meters[label]}`
   }
 }
 


### PR DESCRIPTION
* Add object containing abbreviations and full labels for each unit of measurement
* Update format functions to take a label parameter, which defaults to `abbreviation` but can be overridden
* Update each of the fitness metrics and leaderboards to build and pass an `amountLabel` prop to c11n components