### PR TITLE
Adds whitespace concessions to stripTags method

### DIFF
--- a/source/utils/html/__tests__/html-test.js
+++ b/source/utils/html/__tests__/html-test.js
@@ -20,6 +20,22 @@ describe('Utils | HTML', () => {
       expect(test()).to.eql('Article Title Article body with a link.')
     })
 
+    it('preserves newlines from tags', () => {
+      const test = () =>
+        stripTags('<p>Hello</p><p><a href="#">World</a></p>', true)
+      expect(test()).to.eql('Hello\n\nWorld')
+    })
+
+    it('preserves newlines from input', () => {
+      const test = () =>
+        stripTags(
+          `Lorem
+ipsum`,
+          true
+        )
+      expect(test()).to.eql('Lorem\nipsum')
+    })
+
     it('does not throw is no arg is passed', () => {
       const test = () => stripTags()
       expect(test()).to.eql('')

--- a/source/utils/html/index.js
+++ b/source/utils/html/index.js
@@ -1,5 +1,20 @@
-export const stripTags = (htmlString = '') =>
-  htmlString
-    .replace(/(<([^>]+)>)/gi, '')
-    .trim('')
-    .replace(/\s\s+/g, ' ')
+const removeTags = string =>
+  string
+    .replace(/(<([^>]+)>)/gi, ' ')
+    .replace(/ *\n\n */g, '\n\n')
+    .replace(/ \./g, '.')
+    .trim()
+
+const removeConsecutiveWhitespace = string =>
+  string.replace(/\s\s+/g, ' ').trim()
+
+const removeConsecutiveSpaces = string => string.replace(/ {2,}/g, ' ').trim()
+
+export const stripTags = (htmlString = '', preserveNewlines = false) =>
+  preserveNewlines
+    ? removeConsecutiveSpaces(
+      removeTags(
+        htmlString.replace(/(<\/[p|h1-6]>)\s*(<[p|h1-6]>)/gim, '$1\n\n$2')
+      )
+    )
+    : removeConsecutiveWhitespace(removeTags(htmlString))


### PR DESCRIPTION
There are two changes at play here:

1. Previously when removing tags it would join with no whitespace. This lead to situations where `<p>... hello.</p><p>World ...</p>` would become `... hello.World ...`. Instead now we replace with a space, then strip any excess whitespace later on.
2. With an optional second param, the method will add newlines from tags, or leave as is. e.g. `<p>hello.</p><p>World</p>` becomes 
```
hello.
World
```
and also

```
Some
text <em>that's bold</em>
```
will be
```
Some
text that's bold
```