### PR TITLE
remove cancelled pages from leaderboard

### DIFF
--- a/source/api/leaderboard/justgiving/index.js
+++ b/source/api/leaderboard/justgiving/index.js
@@ -220,6 +220,7 @@ export const deserializeLeaderboard = (supporter, index) => {
         0
     ),
     slug,
+    status: lodashGet(supporter, 'page.status'),
     subtitle: owner || supporter.eventName,
     target: supporter.targetAmount || supporter.target,
     totalDonations: supporter.numberOfSupporters || supporter.donationCount,

--- a/source/components/leaderboard/index.js
+++ b/source/components/leaderboard/index.js
@@ -65,6 +65,7 @@ class Leaderboard extends Component {
 
   handleData (data, excludeOffline, deserializeMethod, limit) {
     const leaderboardData = data
+      .filter(item => item.status !== 'Cancelled')
       .map(deserializeMethod)
       .map(
         item =>


### PR DESCRIPTION
Issue reported here in the US by where a cancelled page is showing up in leaderboard:
https://togetherweshine.blackbaud-sites.com/

You should see Kerri's Test displaying, which is a cancelled page. Make a few small updates to add page status to deserializer and filtering out cancelled pages from the data displayed. Not sure if tyhere are scenarios where we actually want to show cancelled pages, if so feel free to ignore PR and delete.