### PR TITLE
Improve generated team slug names

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "4.0.12",
+  "version": "4.0.13",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/teams/justgiving/index.js
+++ b/source/api/teams/justgiving/index.js
@@ -1,7 +1,6 @@
 import get from 'lodash/get'
 import find from 'lodash/find'
 import slugify from 'slugify'
-import { v4 as uuid } from 'uuid'
 import * as client from '../../../utils/client'
 import { fetchPage, deserializePage } from '../../pages'
 import { paramsSerializer, required } from '../../../utils/params'
@@ -165,11 +164,20 @@ export const checkTeamSlugAvailable = (
       options
     )
     .then(response => response.data.isAvailable)
-    .then(
-      isAvailable =>
-        isAvailable ? slug : [uuid(), slug].join('-').substr(0, 50)
-    )
-    .catch(() => [uuid(), slug].join('-').substr(0, 50))
+    .then(isAvailable => (isAvailable ? slug : appendIdToSlug(slug)))
+    .catch(() => appendIdToSlug(slug))
+}
+
+// Take an existing slug
+// Trim it down it size so it does not exceed to limit of 50
+// Append a small generated unique id
+const appendIdToSlug = slug => {
+  const trimmedSlug = slug.slice(0, 43)
+  const randomId = Math.random()
+    .toString(36)
+    .slice(-6)
+
+  return `${trimmedSlug}-${randomId}`
 }
 
 export const createTeam = params => {


### PR DESCRIPTION
We generate the team slug based on the supplied team name (e.g. Dan's Team becomes dans-team). If this is already taken, we generate a unique slug, but it generates a big ugly one with a UUID.

For example: instead of `dans-team`, it ends up `3ffa29b9-2c19-4a85-8640-ff563b6cacbf-dans-team`. And even worse it trims it to 50 characters as this is the limit in product, so you sometimes end up with slugs like `3ffa29b9-2c19-4a85-8640-ff563b6cacbf-dans-awesome-te` and it gets cut off.

I am proposing we generate shorted unique ids to append to the page name rather than a UUID. I found a little one liner that generates a nice little 6 character random string, and we end up with something like `dans-team-7kkbd8`

We could use a package like shortid or nanoid, but I opted for a one liner rather than yet another package. But I can be swayed if we think it's a better idea.