### PR TITLE
Add support for tag-based totals and leaderboards

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "4.0.14",
+  "version": "5.0.0",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/fitness-leaderboard/__tests__/fetch-test.js
+++ b/source/api/fitness-leaderboard/__tests__/fetch-test.js
@@ -1,6 +1,6 @@
 import moxios from 'moxios'
 import { fetchFitnessLeaderboard } from '..'
-import { instance, updateClient } from '../../../utils/client'
+import { instance, servicesAPI, updateClient } from '../../../utils/client'
 
 describe('Fetch Fitness Leaderboards', () => {
   beforeEach(() => {
@@ -128,11 +128,13 @@ describe('Fetch Fitness Leaderboards', () => {
         headers: { 'x-api-key': 'abcd1234' }
       })
       moxios.install(instance)
+      moxios.install(servicesAPI)
     })
 
     afterEach(() => {
       updateClient({ baseURL: 'https://everydayhero.com' })
       moxios.uninstall(instance)
+      moxios.uninstall(servicesAPI)
     })
 
     it('throws if no params are passed in', () => {
@@ -141,19 +143,20 @@ describe('Fetch Fitness Leaderboards', () => {
     })
 
     it('uses the correct url to fetch a leaderboard', done => {
-      fetchFitnessLeaderboard({ campaign: '12345' })
+      fetchFitnessLeaderboard({ campaign: '12345', useLegacy: false })
       moxios.wait(() => {
         const request = moxios.requests.mostRecent()
+        const data = JSON.parse(request.config.data)
         expect(request.url).to.contain(
-          'https://api.justgiving.com/v1/fitness/campaign'
+          'https://api.blackbaud.services/v1/justgiving/graphql'
         )
-        expect(request.url).to.contain('campaignGuid=12345')
+        expect(data.query).to.contain('campaign_any_distance_12345')
         done()
       })
     })
 
     it('uses the correct url to fetch a leaderboard for multiple campaigns', done => {
-      fetchFitnessLeaderboard({ campaign: ['12345', '98765'] })
+      fetchFitnessLeaderboard({ campaign: ['12345', '98765'], useLegacy: true })
       moxios.wait(() => {
         const request = moxios.requests.mostRecent()
         expect(request.url).to.contain(

--- a/source/api/fitness-leaderboard/everydayhero/index.js
+++ b/source/api/fitness-leaderboard/everydayhero/index.js
@@ -68,6 +68,7 @@ const deserializePage = (item, result, index) => ({
   position: index + 1,
   raised: item.amount.cents,
   slug: item.url && last(item.url.split('/')),
+  subtitle: item.charity_name,
   url: item.url
 })
 

--- a/source/api/fitness-leaderboard/justgiving/index.js
+++ b/source/api/fitness-leaderboard/justgiving/index.js
@@ -21,43 +21,105 @@ const fetchActivePages = pages => {
 export const fetchFitnessLeaderboard = ({
   campaign = required(),
   activeOnly,
-  type,
-  limit,
+  activityType = 'any',
+  endDate,
+  limit = 10,
   offset,
+  sortBy = 'distance',
   startDate,
-  endDate
+  type,
+  useLegacy = true
 }) => {
-  const query = {
-    campaignGuid: campaign,
-    limit: 100,
-    offset: offset || 0,
-    start: startDate,
-    end: endDate
+  if (useLegacy || type === 'teams') {
+    const params = {
+      campaignGuid: campaign,
+      limit: 100,
+      offset: offset || 0,
+      start: startDate,
+      end: endDate
+    }
+
+    return client
+      .get('/v1/fitness/campaign', params, {}, { paramsSerializer })
+      .then(result => (type === 'team' ? result.teams : result.pages))
+      .then(items => items.slice(0, limit || 100))
+      .then(
+        items => (activeOnly && type !== 'team' ? fetchActivePages(items) : items)
+      )
+      .then(items => items.filter(item => item.Details))
+      .then(items => items.map(item => ({ ...item, type: type || 'individual' })))
   }
 
-  return client
-    .get('/v1/fitness/campaign', query, {}, { paramsSerializer })
-    .then(result => (type === 'team' ? result.teams : result.pages))
-    .then(items => items.slice(0, limit || 100))
-    .then(
-      items => (activeOnly && type !== 'team' ? fetchActivePages(items) : items)
-    )
-    .then(items => items.filter(item => item.Details))
-    .then(items => items.map(item => ({ ...item, type: type || 'individual' })))
+  const query = `
+    {
+      leaderboard(
+        id: "campaign_${activityType}_${sortBy}_${campaign}"
+      ) {
+        totals(limit: ${limit}) {
+          tagValueAsNode {
+            ... on Page {
+              slug
+              title
+              summary
+              status
+              legacyId
+              url
+              owner {
+                name
+              }
+              donationSummary {
+                totalAmount {
+                  value
+                  currencyCode
+                }
+              }
+              targetWithCurrency {
+                value
+                currencyCode
+              }
+              heroMedia {
+                ... on ImageMedia {
+                  url
+                }
+              }
+            }
+          }
+          amounts {
+            value
+            unit
+          }
+        }
+      }
+    }
+  `
+
+  return client.servicesAPI
+    .post('/v1/justgiving/graphql', { query })
+    .then(response => response.data)
+    .then(result => get(result, 'data.leaderboard.totals', []))
+    .then(results => results.map(item => ({ ...item, ...item.tagValueAsNode })))
 }
 
 export const deserializeFitnessLeaderboard = (item, index) => ({
+  charity: item.charity_name,
+  distance: item.TotalValue || get(item, 'amounts[1].value'),
+  id: item.ID || item.legacyId,
+  image: get(item, 'heroMedia.url')
+    ? `${get(item, 'heroMedia.url')}?template=Size186x186Crop`
+    : null ||
+      imageUrl(get(item, 'Details.ImageId'), 'Size186x186Crop') ||
+      'https://assets.blackbaud-sites.com/images/supporticon/user.svg',
+  name: get(item, 'Details.Name') || item.title,
   position: index + 1,
-  id: item.ID,
-  name: get(item, 'Details.Name'),
-  slug: get(item, 'Details.Url'),
-  url: [
-    baseUrl(),
-    item.type === 'team' ? 'team' : 'fundraising',
-    get(item, 'Details.Url')
-  ].join('/'),
-  image:
-    imageUrl(get(item, 'Details.ImageId'), 'Size186x186Crop') ||
-    'https://assets.blackbaud-sites.com/images/supporticon/user.svg',
-  distance: item.TotalValue
+  raised: get(item, 'donationSummary.totalAmount.value', 0),
+  slug: get(item, 'Details.Url') || item.slug,
+  status: item.status,
+  subtitle: get(item, 'owner.name'),
+  url:
+    item.url ||
+    [
+      baseUrl(),
+      item.type === 'team' ? 'team' : 'fundraising',
+      get(item, 'Details.Url')
+    ].join('/')
 })

--- a/source/api/fitness-leaderboard/justgiving/index.js
+++ b/source/api/fitness-leaderboard/justgiving/index.js
@@ -1,7 +1,7 @@
 import get from 'lodash/get'
 import { fetchPages } from '../../pages'
 import * as client from '../../../utils/client'
-import { paramsSerializer, required } from '../../../utils/params'
+import { getUID, paramsSerializer, required } from '../../../utils/params'
 import { baseUrl, imageUrl } from '../../../utils/justgiving'
 import { fetchLeaderboard } from '../../../utils/leaderboards'
 import { getMonetaryValue } from '../../../utils/totals'
@@ -34,6 +34,17 @@ export const fetchFitnessLeaderboard = ({
   type,
   useLegacy = true
 }) => {
+  if (tagId || tagValue) {
+    return fetchLeaderboard({
+      activityType,
+      campaign: getUID(campaign),
+      sortBy,
+      tagId,
+      tagValue,
+      type: 'campaign'
+    })
+  }
+
   if (useLegacy || type === 'teams') {
     const params = {
       campaignGuid: campaign,
@@ -59,10 +70,8 @@ export const fetchFitnessLeaderboard = ({
 
   return fetchLeaderboard({
     activityType,
-    campaign,
+    campaign: getUID(campaign),
     sortBy,
-    tagId,
-    tagValue,
     type: 'campaign'
   })
 }
@@ -79,7 +88,7 @@ export const deserializeFitnessLeaderboard = (item, index) => {
       : null ||
         imageUrl(get(item, 'Details.ImageId'), 'Size186x186Crop') ||
         'https://assets.blackbaud-sites.com/images/supporticon/user.svg',
-    name: get(item, 'Details.Name') || item.title,
+    name: get(item, 'Details.Name') || item.title || item.tagValue,
     position: index + 1,
     raised: getMonetaryValue(get(item, 'donationSummary.totalAmount')),
     slug,

--- a/source/api/fitness-totals/__tests__/fitness-test.js
+++ b/source/api/fitness-totals/__tests__/fitness-test.js
@@ -1,7 +1,7 @@
 import moxios from 'moxios'
 import { fetchFitnessTotals, fetchFitnessSummary } from '..'
 import { singleCampaign, singleJGCampaign, multipleCampaigns } from './mocks'
-import { instance, updateClient } from '../../../utils/client'
+import { instance, servicesAPI, updateClient } from '../../../utils/client'
 import fitnessTypes from '../consts/fitness-types'
 
 const totalsEqual = (response, val) => {
@@ -75,27 +75,30 @@ describe('Fetch Fitness Totals', () => {
         headers: { 'x-api-key': 'abcd1234' }
       })
       moxios.install(instance)
+      moxios.install(servicesAPI)
     })
 
     afterEach(() => {
       updateClient({ baseURL: 'https://everydayhero.com' })
       moxios.uninstall(instance)
+      moxios.uninstall(servicesAPI)
     })
 
     it('uses the correct url to fetch totals', done => {
-      fetchFitnessTotals('12345')
+      fetchFitnessTotals({ campaign: '12345', useLegacy: false })
       moxios.wait(() => {
         const request = moxios.requests.mostRecent()
+        const data = JSON.parse(request.config.data)
         expect(request.url).to.contain(
-          'https://api.justgiving.com/v1/fitness/campaign'
+          'https://api.blackbaud.services/v1/justgiving/graphql'
         )
-        expect(request.url).to.contain('campaignGuid=12345')
+        expect(data.query).to.contain('page:campaign:12345')
         done()
       })
     })
 
     it('uses the correct url to fetch totals for multiple campaigns', done => {
-      fetchFitnessTotals(['12345', '98765'])
+      fetchFitnessTotals({ campaign: ['12345', '98765'] })
       moxios.wait(() => {
         const request = moxios.requests.mostRecent()
         expect(request.url).to.contain(
@@ -107,22 +110,14 @@ describe('Fetch Fitness Totals', () => {
     })
 
     it('returns the distance for the campaign', done => {
-      fetchFitnessTotals('12345').then(response => {
-        expect(response.distance).to.equal(100)
-        expect(response.elevation).to.equal(50)
-        done()
-      })
-      moxios.wait(() => {
-        moxios.requests.mostRecent().respondWith(singleJGCampaign)
-      })
-    })
-
-    it('allows params to be passed as an object', done => {
-      fetchFitnessTotals({ campaign: '12345' }).then(response => {
-        expect(response.distance).to.equal(100)
-        expect(response.elevation).to.equal(50)
-        done()
-      })
+      fetchFitnessTotals({ campaign: '12345', useLegacy: false }).then(
+        response => {
+          expect(response.fitnessDistanceTotal).to.equal(100)
+          expect(response.fitnessElevationTotal).to.equal(100)
+          expect(response.fitnessDurationTotal).to.equal(60)
+          done()
+        }
+      )
       moxios.wait(() => {
         moxios.requests.mostRecent().respondWith(singleJGCampaign)
       })

--- a/source/api/fitness-totals/__tests__/mocks/index.js
+++ b/source/api/fitness-totals/__tests__/mocks/index.js
@@ -18,9 +18,69 @@ export const singleCampaign = {
 export const singleJGCampaign = {
   status: 200,
   response: {
-    totalAmount: 100,
-    totalAmountElevation: 50,
-    totalAmountTaken: 100
+    data: {
+      totals: [
+        {
+          measurementDomain: 'any:distance',
+          amounts: [
+            {
+              value: 328.084,
+              unit: 'feet'
+            },
+            {
+              value: 100,
+              unit: 'meters'
+            },
+            {
+              value: 0.0621371,
+              unit: 'miles'
+            },
+            {
+              value: 0.1,
+              unit: 'kilometers'
+            }
+          ]
+        },
+        {
+          measurementDomain: 'any:elevation_gain',
+          amounts: [
+            {
+              value: 328.084,
+              unit: 'feet'
+            },
+            {
+              value: 100,
+              unit: 'meters'
+            },
+            {
+              value: 0.0621371,
+              unit: 'miles'
+            },
+            {
+              value: 0.1,
+              unit: 'kilometers'
+            }
+          ]
+        },
+        {
+          measurementDomain: 'any:elapsed_time',
+          amounts: [
+            {
+              value: 60,
+              unit: 'seconds'
+            },
+            {
+              value: 0.00069444444,
+              unit: 'days'
+            },
+            {
+              value: 0.01666666667,
+              unit: 'hours'
+            }
+          ]
+        }
+      ]
+    }
   }
 }
 

--- a/source/api/fitness-totals/justgiving/index.js
+++ b/source/api/fitness-totals/justgiving/index.js
@@ -1,7 +1,6 @@
-import get from 'lodash/get'
 import * as client from '../../../utils/client'
 import { paramsSerializer, required } from '../../../utils/params'
-import { deserializeTotals } from '../../../utils/totals'
+import { fetchTotals, deserializeTotals } from '../../../utils/totals'
 
 export const fetchFitnessSummary = (campaign = required(), types) =>
   Promise.reject(new Error('This method is not supported for JustGiving'))
@@ -32,25 +31,9 @@ export function fetchFitnessTotals ({
       }))
   }
 
-  const query = `
-    {
-      totals(
-        segment: "page:campaign:${campaign}",
-        tagDefinitionId: "page:campaign",
-        tagValue: "page:campaign:${campaign}"
-      ) {
-        measurementDomain
-        amounts {
-          value
-          unit
-        }
-      }
-    }
-  `
-
-  return client.servicesAPI
-    .post('/v1/justgiving/graphql', { query })
-    .then(response => response.data)
-    .then(result => get(result, 'data.totals', []))
-    .then(deserializeTotals)
+  return fetchTotals({
+    segment: `page:campaign:${campaign}`,
+    tagId: 'page:campaign',
+    tagValue: `page:campaign:${campaign}`
+  }).then(deserializeTotals)
 }

--- a/source/api/leaderboard/justgiving/index.js
+++ b/source/api/leaderboard/justgiving/index.js
@@ -11,11 +11,17 @@ import {
   splitOnDelimiter
 } from '../../../utils/params'
 import { currencySymbol, currencyCode } from '../../../utils/currencies'
+import { fetchLeaderboard as getGraphQLeaderboard } from '../../../utils/leaderboards'
+import { getMonetaryValue } from '../../../utils/totals'
 
 /**
  * @function fetches fundraising pages ranked by funds raised
  */
 export const fetchLeaderboard = (params = required()) => {
+  if (params.tagId || params.tagValue) {
+    return getGraphQLeaderboard(params)
+  }
+
   if (!isEmpty(params.campaign) && params.allPages) {
     return recursivelyFetchJGLeaderboard(
       getUID(params.campaign),
@@ -197,7 +203,7 @@ const recursivelyFetchJGLeaderboard = (
  */
 export const deserializeLeaderboard = (supporter, index) => {
   const isTeam = supporter.type === 'team'
-  const slug = supporter.pageShortName || supporter.shortName
+  const slug = supporter.pageShortName || supporter.shortName || supporter.slug
   const owner =
     lodashGet(supporter, 'pageOwner.fullName') ||
     lodashGet(supporter, 'owner.firstName')
@@ -205,40 +211,55 @@ export const deserializeLeaderboard = (supporter, index) => {
       : null
 
   return {
-    currency: supporter.currencyCode,
+    currency:
+      supporter.currencyCode ||
+      lodashGet(supporter, 'donationSummary.totalAmount.currencyCode'),
     currencySymbol: supporter.currencySymbol,
     donationUrl: isTeam ? null : `${baseUrl()}/fundraising/${slug}/donate`,
-    id: supporter.pageId,
-    image:
-      supporter.defaultImage ||
-      imageUrl(lodashGet(supporter, 'pageImages[0]'), 'Size186x186Crop') ||
-      imageUrl(supporter.photo, 'Size186x186Crop') ||
-      (isTeam
-        ? 'https://assets.blackbaud-sites.com/images/supporticon/user.svg'
-        : apiImageUrl(slug, 'Size186x186Crop')),
+    id: supporter.pageId || supporter.legacyId,
+    image: lodashGet(supporter, 'heroMedia.url')
+      ? `${lodashGet(supporter, 'heroMedia.url')}?template=Size186x186Crop`
+      : supporter.defaultImage ||
+        imageUrl(lodashGet(supporter, 'pageImages[0]'), 'Size186x186Crop') ||
+        imageUrl(supporter.photo, 'Size186x186Crop') ||
+        (isTeam
+          ? 'https://assets.blackbaud-sites.com/images/supporticon/user.svg'
+          : apiImageUrl(slug, 'Size186x186Crop')),
     name:
       supporter.pageTitle ||
       supporter.name ||
+      supporter.title ||
       lodashGet(supporter, 'pageOwner.fullName'),
     offline: parseFloat(
-      supporter.totalRaisedOffline || supporter.raisedOfflineAmount || 0
+      supporter.totalRaisedOffline ||
+        supporter.raisedOfflineAmount ||
+        getMonetaryValue(lodashGet(supporter, 'donationSummary.offlineAmount'))
     ),
-    owner: owner || supporter.owner,
+    owner,
     position: index + 1,
     raised: parseFloat(
       lodashGet(supporter, 'team.donationSummary.totalAmount') ||
-        lodashGet(supporter, 'page.totalAmount') ||
         supporter.donationAmount ||
         supporter.amount ||
         supporter.raisedAmount ||
         supporter.amountRaised ||
+        getMonetaryValue(lodashGet(supporter, 'donationSummary.totalAmount')) ||
         0
     ),
     slug,
-    status: lodashGet(supporter, 'page.status'),
-    subtitle: owner || supporter.eventName,
-    target: supporter.targetAmount || supporter.target,
-    totalDonations: supporter.numberOfSupporters || supporter.donationCount,
-    url: [baseUrl(), isTeam ? 'team' : 'fundraising', slug].join('/')
+    status: lodashGet(supporter, 'page.status') || supporter.status,
+    subtitle:
+      owner || supporter.eventName || lodashGet(supporter, 'owner.name'),
+    target:
+      supporter.targetAmount ||
+      supporter.target ||
+      getMonetaryValue(lodashGet(supporter, 'targetWithCurrency')),
+    totalDonations:
+      supporter.numberOfSupporters ||
+      supporter.donationCount ||
+      lodashGet(supporter, 'donationSummary.donationCount'),
+    url:
+      supporter.url ||
+      [baseUrl(), isTeam ? 'team' : 'fundraising', slug].join('/')
   }
 }

--- a/source/api/leaderboard/justgiving/index.js
+++ b/source/api/leaderboard/justgiving/index.js
@@ -19,7 +19,11 @@ import { getMonetaryValue } from '../../../utils/totals'
  */
 export const fetchLeaderboard = (params = required()) => {
   if (params.tagId || params.tagValue) {
-    return getGraphQLeaderboard(params)
+    return getGraphQLeaderboard({
+      ...params,
+      campaign: getUID(params.campaign),
+      type: 'campaign'
+    })
   }
 
   if (!isEmpty(params.campaign) && params.allPages) {
@@ -229,6 +233,7 @@ export const deserializeLeaderboard = (supporter, index) => {
       supporter.pageTitle ||
       supporter.name ||
       supporter.title ||
+      supporter.tagValue ||
       lodashGet(supporter, 'pageOwner.fullName'),
     offline: parseFloat(
       supporter.totalRaisedOffline ||
@@ -244,6 +249,7 @@ export const deserializeLeaderboard = (supporter, index) => {
         supporter.raisedAmount ||
         supporter.amountRaised ||
         getMonetaryValue(lodashGet(supporter, 'donationSummary.totalAmount')) ||
+        lodashGet(supporter, 'amounts[8].value', 0) ||
         0
     ),
     slug,

--- a/source/components/fitness-leaderboard/index.js
+++ b/source/components/fitness-leaderboard/index.js
@@ -398,7 +398,7 @@ FitnessLeaderboard.defaultProps = {
   page: 1,
   showPage: false,
   sortBy: 'distance',
-  subtitleMethod: item => item.charity,
+  subtitleMethod: item => item.subtitle,
   units: true
 }
 

--- a/source/components/fitness-leaderboard/index.js
+++ b/source/components/fitness-leaderboard/index.js
@@ -77,7 +77,9 @@ class FitnessLeaderboard extends Component {
       limit,
       page,
       groupID,
-      sortBy
+      sortBy,
+      tagId,
+      tagValue
     } = this.props
 
     !refresh &&
@@ -102,7 +104,9 @@ class FitnessLeaderboard extends Component {
       page,
       groupID,
       sortBy,
-      q
+      q,
+      tagId,
+      tagValue
     })
       .then(data => this.removeExcludedPages(excludePageIds, data, type))
       .then(data =>
@@ -332,6 +336,16 @@ FitnessLeaderboard.propTypes = {
    * The group ID to group the leaderboard by (only relevant if type is group)
    */
   groupID: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+
+  /**
+   * The tag ID to group the leaderboard by
+   */
+  tagId: PropTypes.string,
+
+  /**
+   * The tag value to filter by
+   */
+  tagValue: PropTypes.string,
 
   /**
    * Override the deserializeLeaderboard method

--- a/source/components/leaderboard/index.js
+++ b/source/components/leaderboard/index.js
@@ -98,6 +98,8 @@ class Leaderboard extends Component {
       page,
       pageIds,
       startDate,
+      tagId,
+      tagValue,
       type
     } = this.props
 
@@ -124,6 +126,8 @@ class Leaderboard extends Component {
       pageIds,
       q,
       startDate,
+      tagId,
+      tagValue,
       type
     })
       .then(
@@ -318,6 +322,16 @@ Leaderboard.propTypes = {
    * The group ID to group the leaderboard by (only relevant if type is group)
    */
   groupID: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+
+  /**
+   * The tag ID to group the leaderboard by
+   */
+  tagId: PropTypes.string,
+
+  /**
+   * The tag value to filter by
+   */
+  tagValue: PropTypes.string,
 
   /**
    * Override the deserializeLeaderboard method

--- a/source/utils/leaderboards/index.js
+++ b/source/utils/leaderboards/index.js
@@ -1,0 +1,90 @@
+import snakeCase from 'lodash/snakeCase'
+import * as client from '../client'
+import { required } from '../params'
+import { getPrimaryUnit, measurementDomains } from '../tags'
+
+export const fetchLeaderboardDefinition = ({
+  id = required(),
+  measurementDomain = 'any:distance',
+  type = 'campaign'
+}) => {
+  const definitionId = [type, snakeCase(measurementDomain), id].join('_')
+
+  return client
+    .get(`/v1/tags/leaderboard/definition/${definitionId}`)
+    .then(data => data.definition)
+}
+
+export const fetchLeaderboardDefinitions = params =>
+  Promise.all(
+    measurementDomains.map(measurementDomain =>
+      fetchLeaderboardDefinition({ ...params, measurementDomain })
+    )
+  )
+
+export const createLeaderboardDefinition = ({
+  id = required(),
+  conditions = [],
+  label = 'Page Campaign Link',
+  measurementDomain = 'any:distance',
+  name,
+  tagId,
+  type = 'campaign'
+}) => {
+  const segment = ['page', type, id].join(':')
+  const primaryUnit = getPrimaryUnit(measurementDomain)
+  const definitionId = [type, snakeCase(measurementDomain), id, tagId, name]
+    .filter(Boolean)
+    .join('_')
+
+  const payload = {
+    conditions,
+    id: definitionId,
+    measurementDomain,
+    primaryUnit,
+    segment,
+    tagDefinition: {
+      id: tagId || segment,
+      label
+    }
+  }
+
+  return client
+    .post(`/v1/tags/leaderboard/definition/${definitionId}`, payload)
+    .then(data => ({ ...data.definition, updated: true }))
+    .catch(({ data = {} }) => {
+      const errorMessage = data.errorMessage
+
+      if (errorMessage && errorMessage.indexOf('already has totals') > -1) {
+        return Promise.resolve({
+          ...payload,
+          updated: false
+        })
+      }
+
+      return Promise.reject(data)
+    })
+}
+
+export const createLeaderboardDefinitions = params =>
+  Promise.all(
+    measurementDomains.map(measurementDomain =>
+      createLeaderboardDefinition({ ...params, measurementDomain })
+    )
+  )
+
+export const deleteLeaderboardDefinition = ({
+  id = required(),
+  measurementDomain = 'any:distance',
+  type = 'campaign'
+}) => {
+  const definitionId = [type, snakeCase(measurementDomain), id].join('_')
+  return client.destroy(`/v1/tags/leaderboard/definition/${definitionId}`)
+}
+
+export const deleteLeaderboardDefinitions = params =>
+  Promise.all(
+    measurementDomains.map(measurementDomain =>
+      deleteLeaderboardDefinition({ ...params, measurementDomain })
+    )
+  )

--- a/source/utils/tags/index.js
+++ b/source/utils/tags/index.js
@@ -1,0 +1,44 @@
+export const getPrimaryUnit = measurementDomain => {
+  if (measurementDomain.indexOf('activities') > -1) {
+    return 'count'
+  }
+
+  if (measurementDomain.indexOf('donations_made') > -1) {
+    return 'count'
+  }
+
+  if (measurementDomain.indexOf('donations_received') > -1) {
+    return 'gbp'
+  }
+
+  if (measurementDomain.indexOf('elapsed_time') > -1) {
+    return 'seconds'
+  }
+
+  return 'meters'
+}
+
+export const measurementDomains = [
+  'fundraising:donations_received',
+  'fundraising:donations_made',
+  'any:activities',
+  'any:distance',
+  'any:elapsed_time',
+  'any:elevation_gain',
+  'hike:activities',
+  'hike:distance',
+  'hike:elapsed_time',
+  'hike:elevation_gain',
+  'ride:activities',
+  'ride:distance',
+  'ride:elapsed_time',
+  'ride:elevation_gain',
+  'swim:activities',
+  'swim:distance',
+  'swim:elapsed_time',
+  'swim:elevation_gain',
+  'walk:activities',
+  'walk:distance',
+  'walk:elapsed_time',
+  'walk:elevation_gain'
+]

--- a/source/utils/totals/index.js
+++ b/source/utils/totals/index.js
@@ -1,0 +1,96 @@
+import find from 'lodash/find'
+import get from 'lodash/get'
+import { getPrimaryUnit, measurementDomains } from '../tags'
+
+export const deserializeTotals = (totals, currency = 'GBP') =>
+  measurementDomains
+    .map(
+      measurementDomain =>
+        find(totals, { measurementDomain }) || { measurementDomain }
+    )
+    .reduce((acc, { measurementDomain, amounts = [] }) => {
+      const label = measurementDomain.split(':')[0]
+      const unit = getPrimaryUnit(measurementDomain)
+      const value = get(find(amounts, { unit }), 'value', 0)
+
+      switch (measurementDomain) {
+        case 'fundraising:donations_received':
+          return {
+            ...acc,
+            raised: get(
+              find(amounts, { unit: currency.toLowerCase() }),
+              'value',
+              0
+            )
+          }
+
+        case 'fundraising:donations_made':
+          return {
+            ...acc,
+            donations: value
+          }
+
+        case 'any:activities':
+          return {
+            ...acc,
+            fitnessCount: value
+          }
+
+        case 'walk:activities':
+        case 'ride:activities':
+        case 'swim:activities':
+        case 'hike:activities':
+          return {
+            ...acc,
+            [`${label}Count`]: value
+          }
+
+        case 'any:distance':
+          return {
+            ...acc,
+            fitnessDistanceTotal: value
+          }
+
+        case 'walk:distance':
+        case 'ride:distance':
+        case 'swim:distance':
+        case 'hike:distance':
+          return {
+            ...acc,
+            [`${label}DistanceTotal`]: value
+          }
+
+        case 'any:elapsed_time':
+          return {
+            ...acc,
+            fitnessDurationTotal: value
+          }
+
+        case 'walk:elapsed_time':
+        case 'ride:elapsed_time':
+        case 'swim:elapsed_time':
+        case 'hike:elapsed_time':
+          return {
+            ...acc,
+            [`${label}DurationTotal`]: value
+          }
+
+        case 'any:elevation_gain':
+          return {
+            ...acc,
+            fitnessElevationTotal: value
+          }
+
+        case 'walk:elevation_gain':
+        case 'ride:elevation_gain':
+        case 'swim:elevation_gain':
+        case 'hike:elevation_gain':
+          return {
+            ...acc,
+            [`${label}ElevationTotal`]: value
+          }
+
+        default:
+          return acc
+      }
+    }, {})

--- a/source/utils/totals/index.js
+++ b/source/utils/totals/index.js
@@ -31,6 +31,8 @@ export const fetchTotals = ({
     .then(result => get(result, 'data.totals', []))
 }
 
+export const getMonetaryValue = val => get(val, 'value', 0) / 100
+
 export const deserializeTotals = (totals, currency = 'GBP') =>
   measurementDomains
     .map(

--- a/source/utils/totals/index.js
+++ b/source/utils/totals/index.js
@@ -1,6 +1,35 @@
 import find from 'lodash/find'
 import get from 'lodash/get'
+import { servicesAPI } from '../client'
+import { required } from '../params'
 import { getPrimaryUnit, measurementDomains } from '../tags'
+
+export const fetchTotals = ({
+  segment = required(),
+  tagId = required(),
+  tagValue = required()
+}) => {
+  const query = `
+    {
+      totals(
+        segment: "${segment}",
+        tagDefinitionId: "${tagId}",
+        tagValue: "${tagValue}"
+      ) {
+        measurementDomain
+        amounts {
+          value
+          unit
+        }
+      }
+    }
+  `
+
+  return servicesAPI
+    .post('/v1/justgiving/graphql', { query })
+    .then(response => response.data)
+    .then(result => get(result, 'data.totals', []))
+}
 
 export const deserializeTotals = (totals, currency = 'GBP') =>
   measurementDomains


### PR DESCRIPTION
- Create necessary page tags on page creation (Plus some unnecessary ones? I was just trying to cover all the bases...)
- Adds helpers for creation and management of leaderboard definitions
- Update fundraising and fitness totals and leaderboards endpoints to optionally use the GraphQL endpoints if certain params are passed.
- Update the existing fundraising and fitness leaderboard components to include tag params

Still to come in a future PR (this one was already getting really big):

- Updating the relevant totals components to accept tag params

**N.B. The reason I've gone for a major version bump is because of a potentially breaking change for the `fetchFitnessTotals` as used with JG: previously I was accepting either an array or an object of params to match the EDH method (which also now supports both since v3.50.0) but I've updated it so that it just takes an object of params as that's the way we've always used it since introduced. I did a search of our repos to confirm, so it shouldn't affect any existing projects.** 