### PR TITLE
Use MD5 hash for JG leaderboard definition IDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "numbro": "^1.11.0",
     "prop-types": "^15.5.8",
     "slugify": "^1.4.0",
+    "spark-md5": "^3.0.0",
     "url-parse": "^1.4.3"
   },
   "peerDependencies": {

--- a/source/api/fitness-leaderboard/__tests__/fetch-test.js
+++ b/source/api/fitness-leaderboard/__tests__/fetch-test.js
@@ -1,6 +1,7 @@
 import moxios from 'moxios'
 import { fetchFitnessLeaderboard } from '..'
 import { instance, servicesAPI, updateClient } from '../../../utils/client'
+import { hash } from 'spark-md5'
 
 describe('Fetch Fitness Leaderboards', () => {
   beforeEach(() => {
@@ -150,7 +151,7 @@ describe('Fetch Fitness Leaderboards', () => {
         expect(request.url).to.contain(
           'https://api.blackbaud.services/v1/justgiving/graphql'
         )
-        expect(data.query).to.contain('campaign_any_distance_12345')
+        expect(data.query).to.contain(hash('campaign-ad-12345'))
         done()
       })
     })

--- a/source/api/fitness-leaderboard/justgiving/index.js
+++ b/source/api/fitness-leaderboard/justgiving/index.js
@@ -37,7 +37,7 @@ export const fetchFitnessLeaderboard = ({
   if (tagId || tagValue) {
     return fetchLeaderboard({
       activityType,
-      campaign: getUID(campaign),
+      id: getUID(campaign),
       sortBy,
       tagId,
       tagValue,
@@ -70,7 +70,7 @@ export const fetchFitnessLeaderboard = ({
 
   return fetchLeaderboard({
     activityType,
-    campaign: getUID(campaign),
+    id: getUID(campaign),
     sortBy,
     type: 'campaign'
   })

--- a/source/api/leaderboard/justgiving/index.js
+++ b/source/api/leaderboard/justgiving/index.js
@@ -21,7 +21,7 @@ export const fetchLeaderboard = (params = required()) => {
   if (params.tagId || params.tagValue) {
     return getGraphQLeaderboard({
       ...params,
-      campaign: getUID(params.campaign),
+      id: getUID(params.campaign),
       type: 'campaign'
     })
   }


### PR DESCRIPTION
As there is a 100 character limit imposed on leaderboard definition IDs, instead of passing along the constructed string from the naming convention, we are now passing an MD5 hash generated from that constructed string.

Both when creating/deleting the definition, and when fetching related leaderboards we build the relevant hash and pass on to the graphQL API.

I've also added a short code for all the measurement domains to keep the initial string as short as possible.