### PR TITLE
Handle JG page donation form link if page ID is not present

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/donations/justgiving/index.js
+++ b/source/api/donations/justgiving/index.js
@@ -1,8 +1,9 @@
+import numbro from 'numbro'
+import jsonDate from '../../../utils/jsonDate'
+import { stringify } from 'querystringify'
 import { get } from '../../../utils/client'
 import { required } from '../../../utils/params'
-import jsonDate from '../../../utils/jsonDate'
-import numbro from 'numbro'
-import { stringify } from 'querystringify'
+import { baseUrl } from '../../../utils/justgiving'
 
 export const fetchDonation = (id = required()) => get(`/v1/donation/${id}`)
 
@@ -33,7 +34,6 @@ export const buildDonationUrl = ({
   currency = 'GBP',
   ...args
 }) => {
-  const baseUrl = process.env.SUPPORTICON_BASE_URL.replace('api', 'link')
   const params = stringify({
     amount: numbro(amount).format('0.00'),
     currency,
@@ -41,7 +41,7 @@ export const buildDonationUrl = ({
   })
   if (slug || id) {
     return id
-      ? `${baseUrl}/v1/fundraisingpage/donate/pageId/${id}?${params}`
-      : `${baseUrl}/v1/fundraising/${slug}/donate?${params}`
+      ? `${baseUrl('link')}/v1/fundraisingpage/donate/pageId/${id}?${params}`
+      : `${baseUrl('www')}/fundraising/${slug}/donate?${params}`
   }
 }

--- a/source/api/pages/justgiving/index.js
+++ b/source/api/pages/justgiving/index.js
@@ -44,6 +44,7 @@ export const deserializePage = page => {
 
   const offlineAmount = parseFloat(page.totalRaisedOffline || 0)
   const status = page.status || page.pageStatus
+  const id = page.pageId || page.Id
 
   return {
     active: status ? ['Inactive', 'Cancelled'].indexOf(status) === -1 : true,
@@ -55,11 +56,9 @@ export const deserializePage = page => {
     createdAt: jsonDate(page.createdDate) || page.CreatedDate,
     currencyCode: page.currencyCode,
     currencySymbol: page.currencySymbol,
-    donationUrl: [
-      baseUrl('link'),
-      'v1/fundraisingpage/donate/pageId',
-      page.pageId || page.Id
-    ].join('/'),
+    donationUrl: id
+      ? `${baseUrl('link')}/v1/fundraisingpage/donate/pageId/${id}`
+      : `${baseUrl('www')}/fundraising/${shortName}/donate`,
     event: page.Subtext || page.eventId || page.EventId || page.eventName,
     expired: jsonDate(page.expiryDate) && moment(page.expiryDate).isBefore(),
     fitness: page.fitness || {},
@@ -81,7 +80,7 @@ export const deserializePage = page => {
     hasUpdatedImage:
       page.imageCount &&
       parseInt(page.imageCount - getQrCodes(page).length) > 1,
-    id: page.pageId || page.Id,
+    id,
     image:
       getImage() &&
       getImage().split('?')[0] + '?template=CrowdfundingOwnerAvatar',


### PR DESCRIPTION
In a lot of the newer API endpoints page ID is not included, which is required for the existing built donation form URL. This opts for a URL built off the shortName which is (I think) universally included in API responses. Certainly it's included more often at least...

Also, the existing URL based off the shortName in the `buildDonationURL` method didn't work, so I've updated it too.