### PR TITLE
add target to donation total deserializer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supporticon",
-  "version": "5.2.6",
+  "version": "5.2.7",
   "description": "A libary to handle fetching data from Supporter",
   "main": "index.js",
   "scripts": {

--- a/source/api/donation-totals/justgiving/index.js
+++ b/source/api/donation-totals/justgiving/index.js
@@ -105,6 +105,7 @@ export const deserializeDonationTotals = totals => ({
     get(totals, 'donationSummary.totalAmount') ||
     get(totals, 'totals.donationTotalAmount') ||
     0,
+  target: totals.targetAmount,
   offline: totals.offlineAmount || totals.raisedAmountOfflineInGBP || 0,
   donations:
     totals.totalResults ||


### PR DESCRIPTION
Adding target property to donation total deserializer. Not sure all the other property names for when we receive target info, but this property is for when campaign info is returned.